### PR TITLE
RFC D01: Dataset v2 Summary Section

### DIFF
--- a/schema/dataset/latest/dataset.schema.json
+++ b/schema/dataset/latest/dataset.schema.json
@@ -1,12 +1,12 @@
-{
+﻿{
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/HDRUK/schemata/master/schema/dataset/dataset.schema.json",
+  "$id": "http://healthdatagateway.org/schema/dataset.json",
   "type": "object",
   "title": "HDR UK Dataset",
   "description": "HDR UK Dataset Schema",
-  "version": "1.1.7",
   "required": [
     "id",
+    "identifiers",
     "title",
     "abstract",
     "publisher",
@@ -26,103 +26,142 @@
     "language",
     "format",
     "creator",
-    "doi",
     "usageRestrictions"
   ],
   "additionalProperties": true,
   "properties": {
-    "id": {
-      "$id": "#/properties/id",
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-      "minLength": 36,
-      "maxLength": 36,
-      "title": "Dataset identifier",
-      "description": "Dataset identifier"
-    },
-    "identifier": {
-      "$id": "#/properties/identifier",
-      "$comment": "FIX SPEC: Conforms to spec, but this MAY be an array of strings. FIXME: Rename to local identifier",
-      "title": "Local dataset identifier",
-      "description": "Local dataset identifier",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
+    "summary": {
+      "id": {
+        "$id": "#/properties/summary/id",
+        "title": "Dataset identifier",
+        "description": "Dataset identifier (UUIDv4 format)",
+        "allOf": [
+          {
+            "$ref": "#/definitions/uuidv4"
           }
-        }
-      ]
-    },
-    "title": {
-      "$id": "#/properties/title",
-      "title": "Dataset title",
-      "description": "Name of the dataset limited to 80 characters. It should provide a short description of the dataset and be unique across the gateway. If your title is not unique, please add a prefix with your organisation name or identifier to differentiate it from other datasets within the Gateway. Please avoid acronyms wherever possible. Good titles should summarise the content of the dataset and if relevant, the region the dataset covers.",
-      "type": "string",
-      "minLength": 2,
-      "maxLength": 80
-    },
-    "abstract": {
-      "$id": "#/properties/abstract",
-      "title": "Dataset abstract",
-      "description": "Provide a clear and brief descriptive signpost for researchers who are searching for data that may be relevant to their research. The abstract should allow the reader to determine the scope of the data collection and accurately summarise its content. The optimal length is one paragraph (limited to 255 characters) and effective abstracts should avoid long sentences and abbreviations where possible",
-      "type": "string",
-      "minLength": 5,
-      "maxLength": 255
-    },
-    "publisher": {
-      "$id": "#/properties/publisher",
-      "$comment": "Conforms to spec, but this MAY be an an object of organisation",
-      "title": "Dataset publisher",
-      "description": "This is the organisation responsible for running or supporting the data access request process, as well as publishing and maintaining the metadata. In most this will be the same as the HDR UK Organisation (Hub or Alliance Member). However, in some cases this will be different i.e. Tissue Directory are an HDR UK Gateway organisation but coordinate activities across a number of data publishers i.e. Cambridge Blood and Stem Cell Biobank.",
-      "type": "string",
-      "minLength": 2,
-      "maxLength": 80
-    },
-    "contactPoint": {
-      "$id": "#/properties/contactPoint",
-      "title": "The contactPoint schema",
-      "description": "An explanation about the purpose of this instance.",
-      "type": "string",
-      "format": "email"
-    },
-    "accessRights": {
-      "$id": "#/properties/accessRights",
-      "$comment": "FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality is 1:*",
-      "title": "The accessRights schema",
-      "description": "The URL of a webpage where the data access request process and/or guidance is provided. If there is more than one access process i.e. industry vs academic please provide both. If such a resource or the underlying process doesn’t exist, please provide “In Progress”, until both the process and the documentation are ready.",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^In Progress$"
-        },
-        {
-          "type": "string",
-          "format": "uri"
-        },
-        {
-          "type": "array",
-          "items": {
+        ]
+      },
+      "identifiers": {
+        "$id": "#/properties/summary/identifier",
+        "$comment": "FIX SPEC: Conforms to spec, but this MAY be an array of strings.",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ],
+        "title": "Local dataset identifiers",
+        "description": "Local dataset identifier"
+      },
+      "name": {
+        "$id": "#/properties/summary/name",
+        "$comment": "using name from schema.org, title is reserved word in json schema",
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 80,
+        "title": "title",
+        "description": "Name of the dataset limited to 80 characters. It should provide a short description of the dataset and be unique across the gateway. If your title is not unique, please add a prefix with your organisation name or identifier to differentiate it from other datasets within the Gateway. Please avoid acronyms wherever possible. Good titles should summarise the content of the dataset and if relevant, the region the dataset covers."
+      },
+      "abstract": {
+        "$id": "#/properties/summary/abstract",
+        "type": "string",
+        "minLength": 5,
+        "maxLength": 255,
+        "title": "Dataset abstract",
+        "description": "Provide a clear and brief descriptive signpost for researchers who are searching for data that may be relevant to their research. The abstract should allow the reader to determine the scope of the data collection and accurately summarise its content. The optimal length is one paragraph (limited to 255 characters) and effective abstracts should avoid long sentences and abbreviations where possible"
+      },
+      "publisher": {
+        "$id": "#/properties/summary/publisher",
+        "$comment": "Conforms to spec, but this MAY be an an object of organisation",
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 80,
+        "title": "Dataset publisher",
+        "description": "This is the organisation responsible for running or supporting the data access request process, as well as publishing and maintaining the metadata. In most this will be the same as the HDR UK Organisation (Hub or Alliance Member). However, in some cases this will be different i.e. Tissue Directory are an HDR UK Gateway organisation but coordinate activities across a number of data publishers i.e. Cambridge Blood and Stem Cell Biobank."
+      },
+      "contactPoint": {
+        "$id": "#/properties/summary/contactPoint",
+        "type": "string",
+        "format": "email",
+        "title": "The contactPoint schema",
+        "description": "An explanation about the purpose of this instance."
+      },
+      "keywords": {
+        "$id": "#/properties/summary/keywords",
+        "$comment": "Conforms to spec, but this MAY be an array of strings",
+        "anyOf": [
+          {
+            "type": "string",
+            "pattern": "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+            }
+          }
+        ],
+        "type": "string",
+        "pattern": "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*",
+        "title": "The keywords schema",
+        "description": "An explanation about the purpose of this instance."
+      },
+      "doiName": {
+        "$id": "#/properties/summary/doiName",
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "In Progress"
+            ]
+          },
+          {
+            "type": "string",
+            "pattern": "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$",
+            "title": "Digital Object Identifier",
+            "description": "All HDR UK registered datasets should either have a Digital Object Identifier (DOI) or be working towards obtaining one. If a DOI is available, please provide the DOI."
+          }
+        ]
+      },
+      "accessRights": {
+        "$id": "#/properties/accessRights",
+        "$comment": "FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality",
+        "anyOf": [
+          {
+            "type": "string",
+            "pattern": "^In Progress$"
+          },
+          {
             "type": "string",
             "format": "uri"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            }
           }
-        }
-      ]
+        ],
+        "title": "The accessRights schema",
+        "description": "The URL of a webpage where the data access request process and/or guidance is provided. If there is more than one access process i.e. industry vs academic please provide both. If such a resource or the underlying process doesn’t exist, please provide “In Progress”, until both the process and the documentation are ready."
+      }
     },
     "group": {
       "$id": "#/properties/group",
       "$comment": "Conforms to spec, but this MAY be an array of groups",
+      "type": "string",
       "title": "The group schema",
-      "description": "An explanation about the purpose of this instance.",
-      "type": "string"
+      "description": "An explanation about the purpose of this instance."
     },
     "description": {
       "$id": "#/properties/description",
-      "title": "The description schema",
-      "description": "A free-text account of the record. An html account of the data that provides context and scope of the data (limited to 50,000 characters) and/or a resolvable URL that describes the dataset.",
       "anyOf": [
         {
           "type": "string",
@@ -133,13 +172,13 @@
           "type": "string",
           "format": "uri"
         }
-      ]
+      ],
+      "title": "The description schema",
+      "description": "A free-text account of the record. An html account of the data that provides context and scope of the data (limited to 50,000 characters) and/or a resolvable URL that describes the dataset."
     },
     "media": {
       "$id": "#/properties/media",
       "$comment": "FIXME: Conforms to spec, but this SHOULD to be an array of URIs as cardinality 0:*",
-      "title": "The media schema",
-      "description": "Please provide any media associated with the Gateway Organisation using a valid URI. This is an opportunity to provide additional context that could be useful for researchers wanting to undestand more about the dataset and its relevance to their research question. The following formats will be accepted .jpg, .png or .svg, .pdf, .xslx or .docx.",
       "anyOf": [
         {
           "type": "string",
@@ -152,13 +191,13 @@
             "format": "uri"
           }
         }
-      ]
+      ],
+      "title": "The media schema",
+      "description": "Please provide any media associated with the Gateway Organisation using a valid URI. This is an opportunity to provide additional context that could be useful for researchers wanting to undestand more about the dataset and its relevance to their research question. The following formats will be accepted .jpg, .png or .svg, .pdf, .xslx or .docx."
     },
     "purpose": {
       "$id": "#/properties/purpose",
       "$comment": "FIXME: Mandatory, but cardinality 0:* Possibly deprecate.",
-      "title": "The purpose schema",
-      "description": "Pleases indicate the purpose(s) that the dataset was collected. Multiple purposes may be provided",
       "anyOf": [
         {
           "type": "string",
@@ -187,13 +226,13 @@
             ]
           }
         }
-      ]
+      ],
+      "title": "The purpose schema",
+      "description": "Pleases indicate the purpose(s) that the dataset was collected. Multiple purposes may be provided"
     },
     "source": {
       "$id": "#/properties/source",
       "$comment": "FIXME: Mandatory, but cardinality 0:* Possibly deprecate.",
-      "title": "The source schema",
-      "description": "Pleases indicate the source(s) that the dataset was collected. Multiple source(s) may be provided",
       "anyOf": [
         {
           "type": "string",
@@ -220,13 +259,13 @@
             ]
           }
         }
-      ]
+      ],
+      "title": "The source schema",
+      "description": "Pleases indicate the source(s) that the dataset was collected. Multiple source(s) may be provided"
     },
     "setting": {
       "$id": "#/properties/setting",
       "$comment": "FIXME: Mandatory, but cardinality 0:*. Possibly deprecate.",
-      "title": "The setting schema",
-      "description": "Pleases indicate the setting(s) where data was collected. Multiple settings may be provided.",
       "anyOf": [
         {
           "type": "string",
@@ -261,25 +300,25 @@
             ]
           }
         }
-      ]
+      ],
+      "title": "The setting schema",
+      "description": "Pleases indicate the setting(s) where data was collected. Multiple settings may be provided."
     },
     "releaseDate": {
       "$id": "#/properties/releaseDate",
-      "title": "The releaseDate schema",
-      "description": "An explanation about the purpose of this instance.",
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "title": "The releaseDate schema",
+      "description": "An explanation about the purpose of this instance."
     },
     "accessRequestCost": {
       "$id": "#/properties/accessRequestCost",
+      "type": "string",
       "title": "The accessRequestCost schema",
-      "description": "An explanation about the purpose of this instance.",
-      "type": "string"
+      "description": "An explanation about the purpose of this instance."
     },
     "accessRequestDuration": {
       "$id": "#/properties/accessRequestDuration",
-      "title": "The accessRequestDuration schema",
-      "description": "Please provide an indication of the typical processing times based on the types of requests typically received.",
       "type": "string",
       "enum": [
         "<1 Week",
@@ -289,21 +328,21 @@
         "2-6 Months",
         ">6 Months",
         "Other"
-      ]
+      ],
+      "title": "The accessRequestDuration schema",
+      "description": "Please provide an indication of the typical processing times based on the types of requests typically received."
     },
     "accessEnvironment": {
       "$id": "#/properties/accessEnvironment",
-      "title": "The accessEnvironment schema",
-      "description": "Please provide a brief description of the data access environment that is currently available to researchers.",
       "type": "string",
       "minLength": 5,
-      "maxLength": 5000
+      "maxLength": 5000,
+      "title": "The accessEnvironment schema",
+      "description": "Please provide a brief description of the data access environment that is currently available to researchers."
     },
     "usageRestrictions": {
       "$id": "#/properties/usageRestrictions",
       "$comment": "FIXME: Missing from Onboarding tool, so not captured",
-      "title": "The usageRestrictions schema",
-      "description": "Please provide a description of any usage restrictions of key terms and conditions under which access to the dataset is provided.",
       "anyOf": [
         {
           "type": "string",
@@ -316,20 +355,20 @@
             "In Progress"
           ]
         }
-      ]
+      ],
+      "title": "The usageRestrictions schema",
+      "description": "Please provide a description of any usage restrictions of key terms and conditions under which access to the dataset is provided."
     },
     "dataController": {
       "$id": "#/properties/dataController",
-      "title": "The dataController schema",
-      "description": "Data Controller means a person/entity who (either alone or jointly or in common with other persons/entities) determines the purposes for which and the way any Data Subject data, specifically personal data or are to be processed.",
       "type": "string",
       "minLength": 5,
-      "maxLength": 5000
+      "maxLength": 5000,
+      "title": "The dataController schema",
+      "description": "Data Controller means a person/entity who (either alone or jointly or in common with other persons/entities) determines the purposes for which and the way any Data Subject data, specifically personal data or are to be processed."
     },
     "dataProcessor": {
       "$id": "#/properties/dataProcessor",
-      "title": "The dataProcessor schema",
-      "description": "A Data Processor, in relation to any Data Subject data, specifically personal data, means any person/entity (other than an employee of the data controller) who processes the data on behalf of the data controller.",
       "anyOf": [
         {
           "type": "string",
@@ -342,19 +381,19 @@
             "Not Applicable"
           ]
         }
-      ]
+      ],
+      "title": "The dataProcessor schema",
+      "description": "A Data Processor, in relation to any Data Subject data, specifically personal data, means any person/entity (other than an employee of the data controller) who processes the data on behalf of the data controller."
     },
     "license": {
       "$id": "#/properties/license",
+      "type": "string",
       "title": "The license schema",
-      "description": "An explanation about the purpose of this instance.",
-      "type": "string"
+      "description": "An explanation about the purpose of this instance."
     },
     "derivedDatasets": {
       "$id": "#/properties/derivedDatasets",
       "$comment": "FIXME: Conforms to spec, but this SHOULD to be an array of datasets as cardinality 0:*",
-      "title": "The derivedDatasets schema",
-      "description": "Indicate if derived datasets or predefined extracts are available and the type of derivation available.",
       "anyOf": [
         {
           "type": "string",
@@ -374,13 +413,13 @@
             "Not Available"
           ]
         }
-      ]
+      ],
+      "title": "The derivedDatasets schema",
+      "description": "Indicate if derived datasets or predefined extracts are available and the type of derivation available."
     },
     "linkedDataset": {
       "$id": "#/properties/linkedDataset",
       "$comment": "FIXME: If linked $title must start with 'Linked'. FIXME: Conforms to spec, but this SHOULD to be an array of datasets as cardinality 0:*",
-      "title": "The linkedDataset schema",
-      "description": "If applicable, please provide the DOI of other datasets that have previously been linked to this dataset and their availability. If no DOI is available, please provide the title of the datasets that can be linked, where possible using the same title of a dataset previously onboarded.",
       "anyOf": [
         {
           "type": "string",
@@ -400,12 +439,12 @@
             "Not Available"
           ]
         }
-      ]
+      ],
+      "title": "The linkedDataset schema",
+      "description": "If applicable, please provide the DOI of other datasets that have previously been linked to this dataset and their availability. If no DOI is available, please provide the title of the datasets that can be linked, where possible using the same title of a dataset previously onboarded."
     },
     "linkageOpportunity": {
       "$id": "#/properties/linkageOpportunity",
-      "title": "The linkageOpportunity schema",
-      "description": "If applicable, please indicate if there is the opportunity to link this dataset to additional data sources. If possible, please describe the data elements that could be used to link to external data sources i.e. region or postcode could be used to link to open datasets such as air pollution or deprivation indices. In addition, please describe the restricted data elements that cannot be used to link to other datasets.",
       "anyOf": [
         {
           "type": "string"
@@ -418,15 +457,17 @@
           ]
         }
       ],
-      "type": "string"
+      "type": "string",
+      "title": "The linkageOpportunity schema",
+      "description": "If applicable, please indicate if there is the opportunity to link this dataset to additional data sources. If possible, please describe the data elements that could be used to link to external data sources i.e. region or postcode could be used to link to open datasets such as air pollution or deprivation indices. In addition, please describe the restricted data elements that cannot be used to link to other datasets."
     },
     "geographicCoverage": {
       "$id": "#/properties/geographicCoverage",
       "$comment": "FIXME: Update to geoname pattern",
-      "title": "The geographicCoverage schema",
-      "description": "The geographical area covered by the dataset.",
       "type": "string",
       "format": "uri",
+      "title": "The geographicCoverage schema",
+      "description": "The geographical area covered by the dataset.",
       "default": "",
       "examples": [
         "GB"
@@ -434,37 +475,47 @@
     },
     "periodicity": {
       "$id": "#/properties/periodicity",
+      "type": "string",
+      "enum": [
+        "Static",
+        "Annual",
+        "Biennial",
+        "Quaterly",
+        "Bimonthly",
+        "Monthly",
+        "Biweekly",
+        "Daily",
+        "Irregular",
+        "Continious"
+      ],
       "title": "The periodicity schema",
-      "description": "The frequency at which dataset is published.",
-      "$ref": "#/definitions/periodicity"
+      "description": "The frequency at which dataset is published."
     },
     "datasetEndDate": {
       "$id": "#/properties/datasetEndDate",
-      "title": "The datasetEndDate schema",
-      "description": "The end of the time period that the dataset provides coverage for.",
       "type": "string",
-      "format": "date"
+      "format": "date",
+      "title": "The datasetEndDate schema",
+      "description": "The end of the time period that the dataset provides coverage for."
     },
     "datasetStartDate": {
       "$id": "#/properties/datasetStartDate",
-      "title": "The datasetStartDate schema",
-      "description": "The start of the time period that the dataset provides coverage for.",
       "type": "string",
-      "format": "date"
+      "format": "date",
+      "title": "The datasetStartDate schema",
+      "description": "The start of the time period that the dataset provides coverage for."
     },
     "jurisdiction": {
       "$id": "#/properties/jurisdiction",
       "$comment": "FIXME: Add ISO 3166-2 Subdivision code pattern",
-      "title": "The jurisdiction schema",
-      "description": "Please use country code from ISO 3166-1 country codes and the associated ISO 3166-2 for regions, cities, states etc. for the country/state under whose laws the data subjects’ data is collected, processed and stored.",
       "type": "string",
-      "pattern": "^[A-Z]{2}(-[A-Z]{2,3})?$"
+      "pattern": "^[A-Z]{2}(-[A-Z]{2,3})?$",
+      "title": "The jurisdiction schema",
+      "description": "Please use country code from ISO 3166-1 country codes and the associated ISO 3166-2 for regions, cities, states etc. for the country/state under whose laws the data subjects’ data is collected, processed and stored."
     },
     "populationType": {
       "$id": "#/properties/populationType",
       "$comment": "FIXME: Check against SNOMED-CT TERMS. Conforms to spec but MAY be array of strings",
-      "title": "The populationType schema",
-      "description": "Please provide a valid SNOMED CT concept that describes the measure within the dataset i.e. participants in a study, modality, or images with certain characteristics.",
       "anyOf": [
         {
           "type": "string"
@@ -475,20 +526,21 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "title": "The populationType schema",
+      "description": "Please provide a valid SNOMED CT concept that describes the measure within the dataset i.e. participants in a study, modality, or images with certain characteristics."
     },
     "disabmiguatingDescription": {
       "$id": "#/properties/disabmiguatingDescription",
-      "$comment": "FIXME: MDC is not populated with this value",
+      "$comment": "FIXME: Rename MDC response to ageRange according to spec",
+      "type": "string",
+      "pattern": "\\d{1,3}-\\d{1,3}",
       "title": "The disabmiguatingDescription schema",
-      "description": "If SNOMED CT term does not provide sufficient detail, please provide a description that disambiguates the population type.",
-      "type": "string"
+      "description": "If SNOMED CT term does not provide sufficient detail, please provide a description that disambiguates the population type."
     },
     "statisticalPopulation": {
       "$id": "#/properties/statisticalPopulation",
       "$comment": "FIXME: Spec calls this Measured Value",
-      "title": "The statisticalPopulation schema",
-      "description": "An explanation about the purpose of this instance.",
       "anyOf": [
         {
           "type": "string"
@@ -499,75 +551,163 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "title": "The statisticalPopulation schema",
+      "description": "An explanation about the purpose of this instance."
     },
     "ageBand": {
       "$id": "#/properties/ageBand",
       "$comment": "FIXME: Rename MDC response to ageRange according to spec",
+      "type": "string",
+      "pattern": "\\d{1,3}-\\d{1,3}",
       "title": "The ageBand schema",
-      "description": "Please indicate the age range in whole years of participants in the dataset. Please provide range in the following format ‘[min age] – [max age]’ where both the minimum and maximum are whole numbers (integers).",
-      "$ref": "#/definitions/numericRange"
+      "description": "Please indicate the age range in whole years of participants in the dataset. Please provide range in the following format ‘[min age] – [max age]’ where both the minimum and maximum are whole numbers (integers)."
     },
     "physicalSampleAvailability": {
       "$id": "#/properties/physicalSampleAvailability",
-      "$comment": "Conforms to spec, but this MAY be an array of strings",
+      "type": "string",
+      "enum": [
+        "Not Available",
+        "Bone Marrow",
+        "Cancer Cell Lines",
+        "Core Biopsy",
+        "CDNA/MRNA",
+        "DNA",
+        "Faeces",
+        "Immortalized Cel Lines",
+        "MicroRNA",
+        "Peripheral Blood Cells",
+        "Plasma",
+        "PM Tissue",
+        "Primary Cells",
+        "RNA",
+        "Saliva",
+        "Serum",
+        "Swabs",
+        "Tissue",
+        "Urine",
+        "Whole Blood",
+        "Availability To Be Confirmed"
+      ],
       "title": "The physicalSampleAvailability schema",
       "description": "Availability of physical samples associated with the dataset. If samples are available, please indicate the types of samples that are available.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/physicalSampleAvailability"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/physicalSampleAvailability"
-          }
-        }
-      ],
       "default": "",
       "examples": [
         "Not Available"
       ]
     },
-    "keywords": {
-      "$id": "#/properties/keywords",
-      "$comment": "Conforms to spec, but this MAY be an array of strings",
-      "title": "The keywords schema",
-      "description": "An explanation about the purpose of this instance.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/commaSeparatedValues"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/commaSeparatedValues"
-          }
-        }
-      ]
-    },
     "conformsTo": {
-      "title": "The conformsTo schema",
-      "description": "An explanation about the purpose of this instance.",
       "$id": "#/properties/conformsTo",
-      "$ref": "#/definitions/conformsTo"
+      "type": "string",
+      "enum": [
+        "HL7 FHIR",
+        "HL7 V2",
+        "HL7 CDA",
+        "HL7 CCOW",
+        "LOINC",
+        "DICOM",
+        "I2B2",
+        "IHE",
+        "OMOP",
+        "OPENEHR",
+        "SENTINEL",
+        "PCORNET",
+        "LOCAL",
+        "OTHER"
+      ],
+      "title": "The conformsTo schema",
+      "description": "An explanation about the purpose of this instance."
     },
     "controlledVocabulary": {
       "$id": "#/properties/controlledVocabulary",
       "$comment": "FIXME: Confroms to spec, but MAY be a list of strings",
-      "title": "The controlledVocabulary schema",
-      "description": "List any relevant terminologies / ontologies / controlled vocabularies, such as ICD 10 Codes, NHS Data Dictionary National Codes or SNOMED CT International, that are being used by the dataset.",
       "anyOf": [
         {
-          "$ref": "#/definitions/controlledVocabulary"
+          "type": "string",
+          "enum": [
+            "LOCAL",
+            "OPCS4",
+            "READ",
+            "SNOMED CT",
+            "SNOMED RT",
+            "DM+D",
+            "NHS NATIONAL CODES",
+            "ODS",
+            "LOINC",
+            "ICD10",
+            "ICD10CM",
+            "ICD10PCS",
+            "ICD9CM",
+            "ICD9",
+            "ICDO3",
+            "AMT",
+            "APC",
+            "ATC",
+            "CIEL",
+            "HPO",
+            "CPT4",
+            "DPD",
+            "DRG",
+            "HEMONIC",
+            "JMDC",
+            "KCD7",
+            "MULTUM",
+            "NAACCR",
+            "NDC",
+            "NDFRT",
+            "OXMIS",
+            "RXNORM",
+            "RXNORM EXTENSION",
+            "SPL",
+            "OTHER"
+          ]
         },
         {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/controlledVocabulary"
+            "type": "string",
+            "enum": [
+              "LOCAL",
+              "OPCS4",
+              "READ",
+              "SNOMED CT",
+              "SNOMED RT",
+              "DM+D",
+              "NHS NATIONAL CODES",
+              "ODS",
+              "LOINC",
+              "ICD10",
+              "ICD10CM",
+              "ICD10PCS",
+              "ICD9CM",
+              "ICD9",
+              "ICDO3",
+              "AMT",
+              "APC",
+              "ATC",
+              "CIEL",
+              "HPO",
+              "CPT4",
+              "DPD",
+              "DRG",
+              "HEMONIC",
+              "JMDC",
+              "KCD7",
+              "MULTUM",
+              "NAACCR",
+              "NDC",
+              "NDFRT",
+              "OXMIS",
+              "RXNORM",
+              "RXNORM EXTENSION",
+              "SPL",
+              "OTHER"
+            ]
           }
         }
       ],
+      "title": "The controlledVocabulary schema",
+      "description": "List any relevant terminologies / ontologies / controlled vocabularies, such as ICD 10 Codes, NHS Data Dictionary National Codes or SNOMED CT International, that are being used by the dataset.",
       "default": "",
       "examples": [
         "See ConformsTo"
@@ -576,8 +716,6 @@
     "language": {
       "$id": "#/properties/language",
       "$comment": "FIXME: Conforms to spec, but may be a list of strings given cardinality 1:*. Validate against external list of languages. Resources defined by the Library of Congress (ISO 639-1, ISO 639-2) SHOULD be used.",
-      "title": "The language schema",
-      "description": "This should list all the languages in which the dataset metadata and underlying data is made available.",
       "anyOf": [
         {
           "type": "string"
@@ -588,13 +726,13 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "title": "The language schema",
+      "description": "This should list all the languages in which the dataset metadata and underlying data is made available."
     },
     "format": {
       "$id": "#/properties/format",
       "$comment": "FIXME: Conforms to spec, but may be a list of strings given cardinality 1:*. Validate against external list of formats, e.g. https://www.iana.org/assignments/media-types/media-types.xhtml",
-      "title": "The format schema",
-      "description": "If multiple formats are available please specify.",
       "anyOf": [
         {
           "type": "string"
@@ -605,13 +743,15 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "title": "The format schema",
+      "description": "If multiple formats are available please specify."
     },
     "fileSize": {
       "$id": "#/properties/fileSize",
+      "type": "string",
       "title": "The fileSize schema",
       "description": "An explanation about the purpose of this instance.",
-      "type": "string",
       "default": "",
       "examples": [
         "301MB"
@@ -619,15 +759,13 @@
     },
     "creator": {
       "$id": "#/properties/creator",
+      "type": "string",
       "title": "The creator schema",
-      "description": "Please provide the text that you would like included as part of any citation that credits this dataset. This is typically just the name of the publisher. No employee details should be provided.",
-      "type": "string"
+      "description": "Please provide the text that you would like included as part of any citation that credits this dataset. This is typically just the name of the publisher. No employee details should be provided."
     },
     "citations": {
       "$id": "#/properties/citations",
       "$comment": "FIXME: Conforms to spec, but may be a list of citation strings",
-      "title": "The citations schema",
-      "description": "Please provide the keystone paper associated with the dataset. Also include a list of known citations, if available and should be links to existing resources where the dataset has been used or referenced.",
       "anyOf": [
         {
           "type": "string"
@@ -638,27 +776,32 @@
             "type": "string"
           }
         }
-      ]
-    },
-    "doi": {
-      "$id": "#/properties/doi",
-      "title": "Digital Object Identifier",
-      "description": "All HDR UK registered datasets should either have a Digital Object Identifier (DOI) or be working towards obtaining one. If a DOI is available, please provide the DOI.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "In Progress"
-          ]
-        },
-        {
-          "type": "string",
-          "pattern": "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
-        }
-      ]
+      ],
+      "title": "The citations schema",
+      "description": "Please provide the keystone paper associated with the dataset. Also include a list of known citations, if available and should be links to existing resources where the dataset has been used or referenced."
     }
   },
   "definitions": {
+    "uuidv4": {
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "minLength": 36,
+      "maxLength": 36
+    },
+    "eightyCharacters": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 80
+    },
+    "abstractText": {
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 255
+    },
+    "emailAddress": {
+      "type": "string",
+      "format": "email"
+    },
     "commaSeparatedValues": {
       "type": "string",
       "pattern": "([^,]+)"
@@ -666,6 +809,10 @@
     "numericRange": {
       "type": "string",
       "pattern": "\\d{1,3}-\\d{1,3}"
+    },
+    "doi": {
+      "type": "string",
+      "pattern": "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
     },
     "controlledVocabulary": {
       "type": "string",

--- a/schema/dataset/latest/dataset.schema.json
+++ b/schema/dataset/latest/dataset.schema.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "http://healthdatagateway.org/schema/dataset.json",
+  "$id": "https://raw.githubusercontent.com/HDRUK/schemata/master/schema/dataset/dataset.schema.json",
   "type": "object",
   "title": "HDR UK Dataset",
   "description": "HDR UK Dataset Schema",
+  "version": "1.1.7",
   "required": [
     "id",
-    "identifiers",
     "title",
     "abstract",
     "publisher",
@@ -26,142 +26,103 @@
     "language",
     "format",
     "creator",
+    "doi",
     "usageRestrictions"
   ],
   "additionalProperties": true,
   "properties": {
-    "summary": {
-      "id": {
-        "$id": "#/properties/summary/id",
-        "title": "Dataset identifier",
-        "description": "Dataset identifier (UUIDv4 format)",
-        "allOf": [
-          {
-            "$ref": "#/definitions/uuidv4"
-          }
-        ]
-      },
-      "identifiers": {
-        "$id": "#/properties/summary/identifier",
-        "$comment": "FIX SPEC: Conforms to spec, but this MAY be an array of strings.",
-        "anyOf": [
-          {
+    "id": {
+      "$id": "#/properties/id",
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "minLength": 36,
+      "maxLength": 36,
+      "title": "Dataset identifier",
+      "description": "Dataset identifier"
+    },
+    "identifier": {
+      "$id": "#/properties/identifier",
+      "$comment": "FIX SPEC: Conforms to spec, but this MAY be an array of strings. FIXME: Rename to local identifier",
+      "title": "Local dataset identifier",
+      "description": "Local dataset identifier",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
             "type": "string"
-          },
-          {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
           }
-        ],
-        "title": "Local dataset identifiers",
-        "description": "Local dataset identifier"
-      },
-      "name": {
-        "$id": "#/properties/summary/name",
-        "$comment": "using name from schema.org, title is reserved word in json schema",
-        "type": "string",
-        "minLength": 2,
-        "maxLength": 80,
-        "title": "title",
-        "description": "Name of the dataset limited to 80 characters. It should provide a short description of the dataset and be unique across the gateway. If your title is not unique, please add a prefix with your organisation name or identifier to differentiate it from other datasets within the Gateway. Please avoid acronyms wherever possible. Good titles should summarise the content of the dataset and if relevant, the region the dataset covers."
-      },
-      "abstract": {
-        "$id": "#/properties/summary/abstract",
-        "type": "string",
-        "minLength": 5,
-        "maxLength": 255,
-        "title": "Dataset abstract",
-        "description": "Provide a clear and brief descriptive signpost for researchers who are searching for data that may be relevant to their research. The abstract should allow the reader to determine the scope of the data collection and accurately summarise its content. The optimal length is one paragraph (limited to 255 characters) and effective abstracts should avoid long sentences and abbreviations where possible"
-      },
-      "publisher": {
-        "$id": "#/properties/summary/publisher",
-        "$comment": "Conforms to spec, but this MAY be an an object of organisation",
-        "type": "string",
-        "minLength": 2,
-        "maxLength": 80,
-        "title": "Dataset publisher",
-        "description": "This is the organisation responsible for running or supporting the data access request process, as well as publishing and maintaining the metadata. In most this will be the same as the HDR UK Organisation (Hub or Alliance Member). However, in some cases this will be different i.e. Tissue Directory are an HDR UK Gateway organisation but coordinate activities across a number of data publishers i.e. Cambridge Blood and Stem Cell Biobank."
-      },
-      "contactPoint": {
-        "$id": "#/properties/summary/contactPoint",
-        "type": "string",
-        "format": "email",
-        "title": "The contactPoint schema",
-        "description": "An explanation about the purpose of this instance."
-      },
-      "keywords": {
-        "$id": "#/properties/summary/keywords",
-        "$comment": "Conforms to spec, but this MAY be an array of strings",
-        "anyOf": [
-          {
-            "type": "string",
-            "pattern": "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
-          },
-          {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "pattern": "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
-            }
-          }
-        ],
-        "type": "string",
-        "pattern": "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*",
-        "title": "The keywords schema",
-        "description": "An explanation about the purpose of this instance."
-      },
-      "doiName": {
-        "$id": "#/properties/summary/doiName",
-        "anyOf": [
-          {
-            "type": "string",
-            "enum": [
-              "In Progress"
-            ]
-          },
-          {
-            "type": "string",
-            "pattern": "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$",
-            "title": "Digital Object Identifier",
-            "description": "All HDR UK registered datasets should either have a Digital Object Identifier (DOI) or be working towards obtaining one. If a DOI is available, please provide the DOI."
-          }
-        ]
-      },
-      "accessRights": {
-        "$id": "#/properties/accessRights",
-        "$comment": "FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality",
-        "anyOf": [
-          {
-            "type": "string",
-            "pattern": "^In Progress$"
-          },
-          {
+        }
+      ]
+    },
+    "title": {
+      "$id": "#/properties/title",
+      "title": "Dataset title",
+      "description": "Name of the dataset limited to 80 characters. It should provide a short description of the dataset and be unique across the gateway. If your title is not unique, please add a prefix with your organisation name or identifier to differentiate it from other datasets within the Gateway. Please avoid acronyms wherever possible. Good titles should summarise the content of the dataset and if relevant, the region the dataset covers.",
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 80
+    },
+    "abstract": {
+      "$id": "#/properties/abstract",
+      "title": "Dataset abstract",
+      "description": "Provide a clear and brief descriptive signpost for researchers who are searching for data that may be relevant to their research. The abstract should allow the reader to determine the scope of the data collection and accurately summarise its content. The optimal length is one paragraph (limited to 255 characters) and effective abstracts should avoid long sentences and abbreviations where possible",
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 255
+    },
+    "publisher": {
+      "$id": "#/properties/publisher",
+      "$comment": "Conforms to spec, but this MAY be an an object of organisation",
+      "title": "Dataset publisher",
+      "description": "This is the organisation responsible for running or supporting the data access request process, as well as publishing and maintaining the metadata. In most this will be the same as the HDR UK Organisation (Hub or Alliance Member). However, in some cases this will be different i.e. Tissue Directory are an HDR UK Gateway organisation but coordinate activities across a number of data publishers i.e. Cambridge Blood and Stem Cell Biobank.",
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 80
+    },
+    "contactPoint": {
+      "$id": "#/properties/contactPoint",
+      "title": "The contactPoint schema",
+      "description": "An explanation about the purpose of this instance.",
+      "type": "string",
+      "format": "email"
+    },
+    "accessRights": {
+      "$id": "#/properties/accessRights",
+      "$comment": "FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality is 1:*",
+      "title": "The accessRights schema",
+      "description": "The URL of a webpage where the data access request process and/or guidance is provided. If there is more than one access process i.e. industry vs academic please provide both. If such a resource or the underlying process doesn’t exist, please provide “In Progress”, until both the process and the documentation are ready.",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^In Progress$"
+        },
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "type": "array",
+          "items": {
             "type": "string",
             "format": "uri"
-          },
-          {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "uri"
-            }
           }
-        ],
-        "title": "The accessRights schema",
-        "description": "The URL of a webpage where the data access request process and/or guidance is provided. If there is more than one access process i.e. industry vs academic please provide both. If such a resource or the underlying process doesn’t exist, please provide “In Progress”, until both the process and the documentation are ready."
-      }
+        }
+      ]
     },
     "group": {
       "$id": "#/properties/group",
       "$comment": "Conforms to spec, but this MAY be an array of groups",
-      "type": "string",
       "title": "The group schema",
-      "description": "An explanation about the purpose of this instance."
+      "description": "An explanation about the purpose of this instance.",
+      "type": "string"
     },
     "description": {
       "$id": "#/properties/description",
+      "title": "The description schema",
+      "description": "A free-text account of the record. An html account of the data that provides context and scope of the data (limited to 50,000 characters) and/or a resolvable URL that describes the dataset.",
       "anyOf": [
         {
           "type": "string",
@@ -172,13 +133,13 @@
           "type": "string",
           "format": "uri"
         }
-      ],
-      "title": "The description schema",
-      "description": "A free-text account of the record. An html account of the data that provides context and scope of the data (limited to 50,000 characters) and/or a resolvable URL that describes the dataset."
+      ]
     },
     "media": {
       "$id": "#/properties/media",
       "$comment": "FIXME: Conforms to spec, but this SHOULD to be an array of URIs as cardinality 0:*",
+      "title": "The media schema",
+      "description": "Please provide any media associated with the Gateway Organisation using a valid URI. This is an opportunity to provide additional context that could be useful for researchers wanting to undestand more about the dataset and its relevance to their research question. The following formats will be accepted .jpg, .png or .svg, .pdf, .xslx or .docx.",
       "anyOf": [
         {
           "type": "string",
@@ -191,13 +152,13 @@
             "format": "uri"
           }
         }
-      ],
-      "title": "The media schema",
-      "description": "Please provide any media associated with the Gateway Organisation using a valid URI. This is an opportunity to provide additional context that could be useful for researchers wanting to undestand more about the dataset and its relevance to their research question. The following formats will be accepted .jpg, .png or .svg, .pdf, .xslx or .docx."
+      ]
     },
     "purpose": {
       "$id": "#/properties/purpose",
       "$comment": "FIXME: Mandatory, but cardinality 0:* Possibly deprecate.",
+      "title": "The purpose schema",
+      "description": "Pleases indicate the purpose(s) that the dataset was collected. Multiple purposes may be provided",
       "anyOf": [
         {
           "type": "string",
@@ -226,13 +187,13 @@
             ]
           }
         }
-      ],
-      "title": "The purpose schema",
-      "description": "Pleases indicate the purpose(s) that the dataset was collected. Multiple purposes may be provided"
+      ]
     },
     "source": {
       "$id": "#/properties/source",
       "$comment": "FIXME: Mandatory, but cardinality 0:* Possibly deprecate.",
+      "title": "The source schema",
+      "description": "Pleases indicate the source(s) that the dataset was collected. Multiple source(s) may be provided",
       "anyOf": [
         {
           "type": "string",
@@ -259,13 +220,13 @@
             ]
           }
         }
-      ],
-      "title": "The source schema",
-      "description": "Pleases indicate the source(s) that the dataset was collected. Multiple source(s) may be provided"
+      ]
     },
     "setting": {
       "$id": "#/properties/setting",
       "$comment": "FIXME: Mandatory, but cardinality 0:*. Possibly deprecate.",
+      "title": "The setting schema",
+      "description": "Pleases indicate the setting(s) where data was collected. Multiple settings may be provided.",
       "anyOf": [
         {
           "type": "string",
@@ -300,25 +261,25 @@
             ]
           }
         }
-      ],
-      "title": "The setting schema",
-      "description": "Pleases indicate the setting(s) where data was collected. Multiple settings may be provided."
+      ]
     },
     "releaseDate": {
       "$id": "#/properties/releaseDate",
-      "type": "string",
-      "format": "date-time",
       "title": "The releaseDate schema",
-      "description": "An explanation about the purpose of this instance."
+      "description": "An explanation about the purpose of this instance.",
+      "type": "string",
+      "format": "date-time"
     },
     "accessRequestCost": {
       "$id": "#/properties/accessRequestCost",
-      "type": "string",
       "title": "The accessRequestCost schema",
-      "description": "An explanation about the purpose of this instance."
+      "description": "An explanation about the purpose of this instance.",
+      "type": "string"
     },
     "accessRequestDuration": {
       "$id": "#/properties/accessRequestDuration",
+      "title": "The accessRequestDuration schema",
+      "description": "Please provide an indication of the typical processing times based on the types of requests typically received.",
       "type": "string",
       "enum": [
         "<1 Week",
@@ -328,21 +289,21 @@
         "2-6 Months",
         ">6 Months",
         "Other"
-      ],
-      "title": "The accessRequestDuration schema",
-      "description": "Please provide an indication of the typical processing times based on the types of requests typically received."
+      ]
     },
     "accessEnvironment": {
       "$id": "#/properties/accessEnvironment",
+      "title": "The accessEnvironment schema",
+      "description": "Please provide a brief description of the data access environment that is currently available to researchers.",
       "type": "string",
       "minLength": 5,
-      "maxLength": 5000,
-      "title": "The accessEnvironment schema",
-      "description": "Please provide a brief description of the data access environment that is currently available to researchers."
+      "maxLength": 5000
     },
     "usageRestrictions": {
       "$id": "#/properties/usageRestrictions",
       "$comment": "FIXME: Missing from Onboarding tool, so not captured",
+      "title": "The usageRestrictions schema",
+      "description": "Please provide a description of any usage restrictions of key terms and conditions under which access to the dataset is provided.",
       "anyOf": [
         {
           "type": "string",
@@ -355,20 +316,20 @@
             "In Progress"
           ]
         }
-      ],
-      "title": "The usageRestrictions schema",
-      "description": "Please provide a description of any usage restrictions of key terms and conditions under which access to the dataset is provided."
+      ]
     },
     "dataController": {
       "$id": "#/properties/dataController",
+      "title": "The dataController schema",
+      "description": "Data Controller means a person/entity who (either alone or jointly or in common with other persons/entities) determines the purposes for which and the way any Data Subject data, specifically personal data or are to be processed.",
       "type": "string",
       "minLength": 5,
-      "maxLength": 5000,
-      "title": "The dataController schema",
-      "description": "Data Controller means a person/entity who (either alone or jointly or in common with other persons/entities) determines the purposes for which and the way any Data Subject data, specifically personal data or are to be processed."
+      "maxLength": 5000
     },
     "dataProcessor": {
       "$id": "#/properties/dataProcessor",
+      "title": "The dataProcessor schema",
+      "description": "A Data Processor, in relation to any Data Subject data, specifically personal data, means any person/entity (other than an employee of the data controller) who processes the data on behalf of the data controller.",
       "anyOf": [
         {
           "type": "string",
@@ -381,19 +342,19 @@
             "Not Applicable"
           ]
         }
-      ],
-      "title": "The dataProcessor schema",
-      "description": "A Data Processor, in relation to any Data Subject data, specifically personal data, means any person/entity (other than an employee of the data controller) who processes the data on behalf of the data controller."
+      ]
     },
     "license": {
       "$id": "#/properties/license",
-      "type": "string",
       "title": "The license schema",
-      "description": "An explanation about the purpose of this instance."
+      "description": "An explanation about the purpose of this instance.",
+      "type": "string"
     },
     "derivedDatasets": {
       "$id": "#/properties/derivedDatasets",
       "$comment": "FIXME: Conforms to spec, but this SHOULD to be an array of datasets as cardinality 0:*",
+      "title": "The derivedDatasets schema",
+      "description": "Indicate if derived datasets or predefined extracts are available and the type of derivation available.",
       "anyOf": [
         {
           "type": "string",
@@ -413,13 +374,13 @@
             "Not Available"
           ]
         }
-      ],
-      "title": "The derivedDatasets schema",
-      "description": "Indicate if derived datasets or predefined extracts are available and the type of derivation available."
+      ]
     },
     "linkedDataset": {
       "$id": "#/properties/linkedDataset",
       "$comment": "FIXME: If linked $title must start with 'Linked'. FIXME: Conforms to spec, but this SHOULD to be an array of datasets as cardinality 0:*",
+      "title": "The linkedDataset schema",
+      "description": "If applicable, please provide the DOI of other datasets that have previously been linked to this dataset and their availability. If no DOI is available, please provide the title of the datasets that can be linked, where possible using the same title of a dataset previously onboarded.",
       "anyOf": [
         {
           "type": "string",
@@ -439,12 +400,12 @@
             "Not Available"
           ]
         }
-      ],
-      "title": "The linkedDataset schema",
-      "description": "If applicable, please provide the DOI of other datasets that have previously been linked to this dataset and their availability. If no DOI is available, please provide the title of the datasets that can be linked, where possible using the same title of a dataset previously onboarded."
+      ]
     },
     "linkageOpportunity": {
       "$id": "#/properties/linkageOpportunity",
+      "title": "The linkageOpportunity schema",
+      "description": "If applicable, please indicate if there is the opportunity to link this dataset to additional data sources. If possible, please describe the data elements that could be used to link to external data sources i.e. region or postcode could be used to link to open datasets such as air pollution or deprivation indices. In addition, please describe the restricted data elements that cannot be used to link to other datasets.",
       "anyOf": [
         {
           "type": "string"
@@ -457,17 +418,15 @@
           ]
         }
       ],
-      "type": "string",
-      "title": "The linkageOpportunity schema",
-      "description": "If applicable, please indicate if there is the opportunity to link this dataset to additional data sources. If possible, please describe the data elements that could be used to link to external data sources i.e. region or postcode could be used to link to open datasets such as air pollution or deprivation indices. In addition, please describe the restricted data elements that cannot be used to link to other datasets."
+      "type": "string"
     },
     "geographicCoverage": {
       "$id": "#/properties/geographicCoverage",
       "$comment": "FIXME: Update to geoname pattern",
-      "type": "string",
-      "format": "uri",
       "title": "The geographicCoverage schema",
       "description": "The geographical area covered by the dataset.",
+      "type": "string",
+      "format": "uri",
       "default": "",
       "examples": [
         "GB"
@@ -475,47 +434,37 @@
     },
     "periodicity": {
       "$id": "#/properties/periodicity",
-      "type": "string",
-      "enum": [
-        "Static",
-        "Annual",
-        "Biennial",
-        "Quaterly",
-        "Bimonthly",
-        "Monthly",
-        "Biweekly",
-        "Daily",
-        "Irregular",
-        "Continious"
-      ],
       "title": "The periodicity schema",
-      "description": "The frequency at which dataset is published."
+      "description": "The frequency at which dataset is published.",
+      "$ref": "#/definitions/periodicity"
     },
     "datasetEndDate": {
       "$id": "#/properties/datasetEndDate",
-      "type": "string",
-      "format": "date",
       "title": "The datasetEndDate schema",
-      "description": "The end of the time period that the dataset provides coverage for."
+      "description": "The end of the time period that the dataset provides coverage for.",
+      "type": "string",
+      "format": "date"
     },
     "datasetStartDate": {
       "$id": "#/properties/datasetStartDate",
-      "type": "string",
-      "format": "date",
       "title": "The datasetStartDate schema",
-      "description": "The start of the time period that the dataset provides coverage for."
+      "description": "The start of the time period that the dataset provides coverage for.",
+      "type": "string",
+      "format": "date"
     },
     "jurisdiction": {
       "$id": "#/properties/jurisdiction",
       "$comment": "FIXME: Add ISO 3166-2 Subdivision code pattern",
-      "type": "string",
-      "pattern": "^[A-Z]{2}(-[A-Z]{2,3})?$",
       "title": "The jurisdiction schema",
-      "description": "Please use country code from ISO 3166-1 country codes and the associated ISO 3166-2 for regions, cities, states etc. for the country/state under whose laws the data subjects’ data is collected, processed and stored."
+      "description": "Please use country code from ISO 3166-1 country codes and the associated ISO 3166-2 for regions, cities, states etc. for the country/state under whose laws the data subjects’ data is collected, processed and stored.",
+      "type": "string",
+      "pattern": "^[A-Z]{2}(-[A-Z]{2,3})?$"
     },
     "populationType": {
       "$id": "#/properties/populationType",
       "$comment": "FIXME: Check against SNOMED-CT TERMS. Conforms to spec but MAY be array of strings",
+      "title": "The populationType schema",
+      "description": "Please provide a valid SNOMED CT concept that describes the measure within the dataset i.e. participants in a study, modality, or images with certain characteristics.",
       "anyOf": [
         {
           "type": "string"
@@ -526,21 +475,20 @@
             "type": "string"
           }
         }
-      ],
-      "title": "The populationType schema",
-      "description": "Please provide a valid SNOMED CT concept that describes the measure within the dataset i.e. participants in a study, modality, or images with certain characteristics."
+      ]
     },
     "disabmiguatingDescription": {
       "$id": "#/properties/disabmiguatingDescription",
-      "$comment": "FIXME: Rename MDC response to ageRange according to spec",
-      "type": "string",
-      "pattern": "\\d{1,3}-\\d{1,3}",
+      "$comment": "FIXME: MDC is not populated with this value",
       "title": "The disabmiguatingDescription schema",
-      "description": "If SNOMED CT term does not provide sufficient detail, please provide a description that disambiguates the population type."
+      "description": "If SNOMED CT term does not provide sufficient detail, please provide a description that disambiguates the population type.",
+      "type": "string"
     },
     "statisticalPopulation": {
       "$id": "#/properties/statisticalPopulation",
       "$comment": "FIXME: Spec calls this Measured Value",
+      "title": "The statisticalPopulation schema",
+      "description": "An explanation about the purpose of this instance.",
       "anyOf": [
         {
           "type": "string"
@@ -551,163 +499,75 @@
             "type": "string"
           }
         }
-      ],
-      "title": "The statisticalPopulation schema",
-      "description": "An explanation about the purpose of this instance."
+      ]
     },
     "ageBand": {
       "$id": "#/properties/ageBand",
       "$comment": "FIXME: Rename MDC response to ageRange according to spec",
-      "type": "string",
-      "pattern": "\\d{1,3}-\\d{1,3}",
       "title": "The ageBand schema",
-      "description": "Please indicate the age range in whole years of participants in the dataset. Please provide range in the following format ‘[min age] – [max age]’ where both the minimum and maximum are whole numbers (integers)."
+      "description": "Please indicate the age range in whole years of participants in the dataset. Please provide range in the following format ‘[min age] – [max age]’ where both the minimum and maximum are whole numbers (integers).",
+      "$ref": "#/definitions/numericRange"
     },
     "physicalSampleAvailability": {
       "$id": "#/properties/physicalSampleAvailability",
-      "type": "string",
-      "enum": [
-        "Not Available",
-        "Bone Marrow",
-        "Cancer Cell Lines",
-        "Core Biopsy",
-        "CDNA/MRNA",
-        "DNA",
-        "Faeces",
-        "Immortalized Cel Lines",
-        "MicroRNA",
-        "Peripheral Blood Cells",
-        "Plasma",
-        "PM Tissue",
-        "Primary Cells",
-        "RNA",
-        "Saliva",
-        "Serum",
-        "Swabs",
-        "Tissue",
-        "Urine",
-        "Whole Blood",
-        "Availability To Be Confirmed"
-      ],
+      "$comment": "Conforms to spec, but this MAY be an array of strings",
       "title": "The physicalSampleAvailability schema",
       "description": "Availability of physical samples associated with the dataset. If samples are available, please indicate the types of samples that are available.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/physicalSampleAvailability"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/physicalSampleAvailability"
+          }
+        }
+      ],
       "default": "",
       "examples": [
         "Not Available"
       ]
     },
-    "conformsTo": {
-      "$id": "#/properties/conformsTo",
-      "type": "string",
-      "enum": [
-        "HL7 FHIR",
-        "HL7 V2",
-        "HL7 CDA",
-        "HL7 CCOW",
-        "LOINC",
-        "DICOM",
-        "I2B2",
-        "IHE",
-        "OMOP",
-        "OPENEHR",
-        "SENTINEL",
-        "PCORNET",
-        "LOCAL",
-        "OTHER"
-      ],
-      "title": "The conformsTo schema",
-      "description": "An explanation about the purpose of this instance."
-    },
-    "controlledVocabulary": {
-      "$id": "#/properties/controlledVocabulary",
-      "$comment": "FIXME: Confroms to spec, but MAY be a list of strings",
+    "keywords": {
+      "$id": "#/properties/keywords",
+      "$comment": "Conforms to spec, but this MAY be an array of strings",
+      "title": "The keywords schema",
+      "description": "An explanation about the purpose of this instance.",
       "anyOf": [
         {
-          "type": "string",
-          "enum": [
-            "LOCAL",
-            "OPCS4",
-            "READ",
-            "SNOMED CT",
-            "SNOMED RT",
-            "DM+D",
-            "NHS NATIONAL CODES",
-            "ODS",
-            "LOINC",
-            "ICD10",
-            "ICD10CM",
-            "ICD10PCS",
-            "ICD9CM",
-            "ICD9",
-            "ICDO3",
-            "AMT",
-            "APC",
-            "ATC",
-            "CIEL",
-            "HPO",
-            "CPT4",
-            "DPD",
-            "DRG",
-            "HEMONIC",
-            "JMDC",
-            "KCD7",
-            "MULTUM",
-            "NAACCR",
-            "NDC",
-            "NDFRT",
-            "OXMIS",
-            "RXNORM",
-            "RXNORM EXTENSION",
-            "SPL",
-            "OTHER"
-          ]
+          "$ref": "#/definitions/commaSeparatedValues"
         },
         {
           "type": "array",
           "items": {
-            "type": "string",
-            "enum": [
-              "LOCAL",
-              "OPCS4",
-              "READ",
-              "SNOMED CT",
-              "SNOMED RT",
-              "DM+D",
-              "NHS NATIONAL CODES",
-              "ODS",
-              "LOINC",
-              "ICD10",
-              "ICD10CM",
-              "ICD10PCS",
-              "ICD9CM",
-              "ICD9",
-              "ICDO3",
-              "AMT",
-              "APC",
-              "ATC",
-              "CIEL",
-              "HPO",
-              "CPT4",
-              "DPD",
-              "DRG",
-              "HEMONIC",
-              "JMDC",
-              "KCD7",
-              "MULTUM",
-              "NAACCR",
-              "NDC",
-              "NDFRT",
-              "OXMIS",
-              "RXNORM",
-              "RXNORM EXTENSION",
-              "SPL",
-              "OTHER"
-            ]
+            "$ref": "#/definitions/commaSeparatedValues"
+          }
+        }
+      ]
+    },
+    "conformsTo": {
+      "title": "The conformsTo schema",
+      "description": "An explanation about the purpose of this instance.",
+      "$id": "#/properties/conformsTo",
+      "$ref": "#/definitions/conformsTo"
+    },
+    "controlledVocabulary": {
+      "$id": "#/properties/controlledVocabulary",
+      "$comment": "FIXME: Confroms to spec, but MAY be a list of strings",
+      "title": "The controlledVocabulary schema",
+      "description": "List any relevant terminologies / ontologies / controlled vocabularies, such as ICD 10 Codes, NHS Data Dictionary National Codes or SNOMED CT International, that are being used by the dataset.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/controlledVocabulary"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/controlledVocabulary"
           }
         }
       ],
-      "title": "The controlledVocabulary schema",
-      "description": "List any relevant terminologies / ontologies / controlled vocabularies, such as ICD 10 Codes, NHS Data Dictionary National Codes or SNOMED CT International, that are being used by the dataset.",
       "default": "",
       "examples": [
         "See ConformsTo"
@@ -716,6 +576,8 @@
     "language": {
       "$id": "#/properties/language",
       "$comment": "FIXME: Conforms to spec, but may be a list of strings given cardinality 1:*. Validate against external list of languages. Resources defined by the Library of Congress (ISO 639-1, ISO 639-2) SHOULD be used.",
+      "title": "The language schema",
+      "description": "This should list all the languages in which the dataset metadata and underlying data is made available.",
       "anyOf": [
         {
           "type": "string"
@@ -726,13 +588,13 @@
             "type": "string"
           }
         }
-      ],
-      "title": "The language schema",
-      "description": "This should list all the languages in which the dataset metadata and underlying data is made available."
+      ]
     },
     "format": {
       "$id": "#/properties/format",
       "$comment": "FIXME: Conforms to spec, but may be a list of strings given cardinality 1:*. Validate against external list of formats, e.g. https://www.iana.org/assignments/media-types/media-types.xhtml",
+      "title": "The format schema",
+      "description": "If multiple formats are available please specify.",
       "anyOf": [
         {
           "type": "string"
@@ -743,15 +605,13 @@
             "type": "string"
           }
         }
-      ],
-      "title": "The format schema",
-      "description": "If multiple formats are available please specify."
+      ]
     },
     "fileSize": {
       "$id": "#/properties/fileSize",
-      "type": "string",
       "title": "The fileSize schema",
       "description": "An explanation about the purpose of this instance.",
+      "type": "string",
       "default": "",
       "examples": [
         "301MB"
@@ -759,13 +619,15 @@
     },
     "creator": {
       "$id": "#/properties/creator",
-      "type": "string",
       "title": "The creator schema",
-      "description": "Please provide the text that you would like included as part of any citation that credits this dataset. This is typically just the name of the publisher. No employee details should be provided."
+      "description": "Please provide the text that you would like included as part of any citation that credits this dataset. This is typically just the name of the publisher. No employee details should be provided.",
+      "type": "string"
     },
     "citations": {
       "$id": "#/properties/citations",
       "$comment": "FIXME: Conforms to spec, but may be a list of citation strings",
+      "title": "The citations schema",
+      "description": "Please provide the keystone paper associated with the dataset. Also include a list of known citations, if available and should be links to existing resources where the dataset has been used or referenced.",
       "anyOf": [
         {
           "type": "string"
@@ -776,32 +638,27 @@
             "type": "string"
           }
         }
-      ],
-      "title": "The citations schema",
-      "description": "Please provide the keystone paper associated with the dataset. Also include a list of known citations, if available and should be links to existing resources where the dataset has been used or referenced."
+      ]
+    },
+    "doi": {
+      "$id": "#/properties/doi",
+      "title": "Digital Object Identifier",
+      "description": "All HDR UK registered datasets should either have a Digital Object Identifier (DOI) or be working towards obtaining one. If a DOI is available, please provide the DOI.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "In Progress"
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
+        }
+      ]
     }
   },
   "definitions": {
-    "uuidv4": {
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-      "minLength": 36,
-      "maxLength": 36
-    },
-    "eightyCharacters": {
-      "type": "string",
-      "minLength": 2,
-      "maxLength": 80
-    },
-    "abstractText": {
-      "type": "string",
-      "minLength": 5,
-      "maxLength": 255
-    },
-    "emailAddress": {
-      "type": "string",
-      "format": "email"
-    },
     "commaSeparatedValues": {
       "type": "string",
       "pattern": "([^,]+)"
@@ -809,10 +666,6 @@
     "numericRange": {
       "type": "string",
       "pattern": "\\d{1,3}-\\d{1,3}"
-    },
-    "doi": {
-      "type": "string",
-      "pattern": "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
     },
     "controlledVocabulary": {
       "type": "string",

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -43,7 +43,8 @@ properties:
     "$id": "#/properties/identifier"
     title: Local Dataset Identifiers
     description: Local dataset identifier
-    allOf:
+    anyOf:
+    - "$ref": "#/definitions/commaSeperatedValues"
     - type: array
       contains:
         type: string

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -644,6 +644,7 @@ definitions:
   doi:
     type: string
     pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
+  
   controlledVocabulary:
     type: string
     enum:

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -3,6 +3,7 @@
 type: object
 title: HDR UK Dataset
 description: HDR UK Dataset Schema
+
 required:
 - id
 - identifiers
@@ -25,8 +26,11 @@ required:
 - language
 - format
 - creator
+- doi
 - usageRestrictions
+
 additionalProperties: true
+
 properties:
   summary:
     id:
@@ -103,8 +107,8 @@ properties:
       pattern: "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
       title: The keywords schema
       description: An explanation about the purpose of this instance.
-    doiName:
-      "$id": "#/properties/summary/doiName"
+    doi:
+      "$id": "#/properties/summary/doi"
       anyOf:
       - type: string
         enum:

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -7,6 +7,7 @@ version: "1.1.7"
 
 required:
 - id
+- identifier
 - title
 - abstract
 - publisher
@@ -26,7 +27,6 @@ required:
 - language
 - format
 - creator
-- doi
 - usageRestrictions
 
 additionalProperties: true
@@ -34,72 +34,119 @@ additionalProperties: true
 properties:
   id:
     "$id": "#/properties/id"
-    type: string
-    pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-    minLength: 36
-    maxLength: 36
-    title: Dataset identifier
-    description: Dataset identifier
+    title: Dataset Identifier
+    description: Dataset identifier (UUIDv4 format)
+    allOf:
+    - "$ref": "#/definitions/uuidv4"
   
-  identifier:
+  identifiers:
     "$id": "#/properties/identifier"
-    "$comment": 'FIX SPEC: Conforms to spec, but this MAY be an array of strings.
-      FIXME: Rename to local identifier'
-    title: Local dataset identifier
+    title: Local Dataset Identifiers
     description: Local dataset identifier
-    anyOf:
-    - type: string
+    allOf:
     - type: array
-      items:
+      contains:
         type: string
+      uniqueItems: true
   
   title:
     "$id": "#/properties/title"
-    title: Dataset title
+    "$comment": "dct:title"
+    title: Title
     description: Name of the dataset limited to 80 characters. It should provide a
       short description of the dataset and be unique across the gateway. If your title
       is not unique, please add a prefix with your organisation name or identifier
       to differentiate it from other datasets within the Gateway. Please avoid acronyms
       wherever possible. Good titles should summarise the content of the dataset and
       if relevant, the region the dataset covers.
-    type: string
-    minLength: 2
-    maxLength: 80
+    allOf:
+    - "$ref": "#/definitions/eightyCharacters"
+    examples:
+    - North West London COVID-19 Patient Level Situation Report
   
   abstract:
     "$id": "#/properties/abstract"
-    title: Dataset abstract
-    description: Provide a clear and brief descriptive signpost for researchers who
-      are searching for data that may be relevant to their research. The abstract
-      should allow the reader to determine the scope of the data collection and accurately
-      summarise its content. The optimal length is one paragraph (limited to 255 characters)
-      and effective abstracts should avoid long sentences and abbreviations where
-      possible
-    type: string
-    minLength: 5
-    maxLength: 255
+    "$comment": dct:abstract
+    title: Abstract
+    description: 'Provide a clear and brief descriptive signpost for researchers
+        who are searching for data that may be relevant to their research. The abstract
+        should allow the reader to determine the scope of the data collection and
+        accurately summarise its content. The optimal length is one paragraph (limited
+        to 255 characters) and effective abstracts should avoid long sentences and
+        abbreviations where possible. Note: Researchers will view Titles and Abstracts
+        when searching for datasets and choosing whether to explore their content
+        further. Abstracts must be different from the full description for a dataset.'
+    allOf:
+    - "$ref": "#/definitions/abstractText"
+    examples:
+    - CPRD Aurum contains primary care data contributed by General Practitioner
+      (GP) practices using EMIS Web® including patient registration information
+      and all care events that GPs have chosen to record as part of their usual
+      medical practice.
   
   publisher:
     "$id": "#/properties/publisher"
-    "$comment": Conforms to spec, but this MAY be an an object of organisation
-    title: Dataset publisher
-    description: This is the organisation responsible for running or supporting the
-      data access request process, as well as publishing and maintaining the metadata.
-      In most this will be the same as the HDR UK Organisation (Hub or Alliance Member).
-      However, in some cases this will be different i.e. Tissue Directory are an HDR
-      UK Gateway organisation but coordinate activities across a number of data publishers
-      i.e. Cambridge Blood and Stem Cell Biobank.
-    type: string
-    minLength: 2
-    maxLength: 80
+    "$comment": dct:publisher Conforms to spec, but this MAY be an an object of organisation
+    title: Publisher
+    description: 'Completion Notes: This is the organisation responsible for running
+      or supporting the data access request process, as well as publishing and
+      maintaining the metadata. In most this will be the same as the HDR UK Organisation
+      (Hub or Alliance Member). However, in some cases this will be different
+      i.e. Tissue Directory are an HDR UK Gateway organisation but coordinate
+      activities across a number of data publishers i.e. Cambridge Blood and Stem
+      Cell Biobank.'
+    allOf:
+    - "$ref": "#/definitions/eightyCharacters"
+    examples:
+    - Cambridge Blood and Stem Cell Biobank
   
   contactPoint:
     "$id": "#/properties/contactPoint"
-    title: The contactPoint schema
-    description: An explanation about the purpose of this instance.
-    type: string
-    format: email
+    "$comment": dcat:contactPoint
+    title: Contact Point
+    description: 'Please provide a valid email address that can be used to coordinate
+      data access requests with the publisher. Organisations are expected to provide
+      a dedicated email address associated with the data access request process.
+      Notes: An employee’s email address can only be provided on a temporary basis
+      and if one is provided an explicit consent must be obtained for this purpose.'
+    allOf:
+    - "$ref": "#/definitions/emailAddress"
   
+  keywords:
+    "$id": "#/properties/keywords"
+    "$comment": dcat:keyword Conforms to spec, but this MAY be an array of strings
+    title: Keywords
+    description: 'Please provide relevant and specific keywords that can improve
+      the SEO of your dataset as a comma separated list. Notes: Onboarding portal
+      will suggest keywords based on title, abstract and description. We are compiling
+      a standardised list of keywords and synonyms across datasets to make filtering
+      easier for users.'
+    anyOf:
+    - "$ref": "#/definitions/commaSeperatedValues"
+    - type: array
+      contains:
+        type: string
+      uniqueItems: true
+      minItems: 1
+  
+  doi:
+    "$id": "#/properties/doi"
+    title: Digital Object Identifier
+    description: 'Registered datasets should either have a Digital Object Identifier
+      (DOI) or be working towards obtaining one. If a DOI is available, please
+      provide the DOI. If a DOI has not been created for the dataset, please provide
+      a default value: “In Progress” whilst you create your DOI. You can either
+      use the HDR UK Onboarding Portal (HOP) to mint a DOI for your dataset or
+      your chosen alternative means. Note: This is not the DOI of the publication(s)
+      associated with the dataset.'
+    anyOf:
+    - type: string
+      enum:
+      - In Progress
+    - "$ref": "#/definitions/doi"
+    examples:
+    - 10.3399/bjgp17X692645
+
   accessRights:
     "$id": "#/properties/accessRights"
     "$comment": 'FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality
@@ -486,17 +533,6 @@ properties:
     examples:
     - Not Available
   
-  keywords:
-    "$id": "#/properties/keywords"
-    "$comment": Conforms to spec, but this MAY be an array of strings
-    title: The keywords schema
-    description: An explanation about the purpose of this instance.
-    anyOf:
-    - "$ref": "#/definitions/commaSeparatedValues"
-    - type: array
-      items:
-        "$ref": "#/definitions/commaSeparatedValues"
-  
   conformsTo:
     title: The conformsTo schema
     description: An explanation about the purpose of this instance.
@@ -574,21 +610,28 @@ properties:
     - type: array
       items:
         type: string
-  
-  doi:
-    "$id": "#/properties/doi"
-    title: Digital Object Identifier
-    description: All HDR UK registered datasets should either have a Digital Object
-      Identifier (DOI) or be working towards obtaining one. If a DOI is available,
-      please provide the DOI.
-    anyOf:
-    - type: string
-      enum:
-      - In Progress
-    - type: string
-      pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
 
 definitions:
+  uuidv4:
+    type: string
+    pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    minLength: 36
+    maxLength: 36
+  
+  eightyCharacters:
+    type: string
+    minLength: 2
+    maxLength: 80
+  
+  abstractText:
+    type: string
+    minLength: 5
+    maxLength: 255
+  
+  emailAddress:
+    type: string
+    format: email
+  
   commaSeparatedValues:
     type: string
     pattern: "([^,]+)"
@@ -597,6 +640,9 @@ definitions:
     type: string
     pattern: "\\d{1,3}-\\d{1,3}"
   
+  doi:
+    type: string
+    pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
   controlledVocabulary:
     type: string
     enum:

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -45,14 +45,14 @@ properties:
           type: string
       title: Local dataset identifiers
       description: Local dataset identifier
-    name:
-      "$id": "#/properties/summary/name"
-      "$comment": "using name from schema.org, title is reserved word in json schema"
+    title:
+      "$id": "#/properties/summary/title"
+      "$comment": "title is reserved word in json schema"
       type: string
       minLength: 2
       maxLength: 80
       title: title
-      description: Name of the dataset limited to 80 characters. It should provide a
+      description: Title of the dataset limited to 80 characters. It should provide a
         short description of the dataset and be unique across the gateway. If your title
         is not unique, please add a prefix with your organisation name or identifier
         to differentiate it from other datasets within the Gateway. Please avoid acronyms

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -1,13 +1,11 @@
-"$schema": "http://json-schema.org/draft-07/schema"
-"$id": "https://raw.githubusercontent.com/HDRUK/schemata/master/schema/dataset/dataset.schema.json"
+"$schema": http://json-schema.org/draft-07/schema
+"$id": http://healthdatagateway.org/schema/dataset.json
 type: object
 title: HDR UK Dataset
 description: HDR UK Dataset Schema
-version: "1.1.7"
-
 required:
 - id
-- identifier
+- identifiers
 - title
 - abstract
 - publisher
@@ -28,176 +26,135 @@ required:
 - format
 - creator
 - usageRestrictions
-
 additionalProperties: true
-
 properties:
-  id:
-    "$id": "#/properties/id"
-    title: Identifier
-    description: Dataset identifier (UUIDv4 format)
-    allOf:
-    - "$ref": "#/definitions/uuidv4"
-  
-  identifiers:
-    "$id": "#/properties/identifier"
-    title: Local Dataset Identifiers
-    description: Local dataset identifier
-    anyOf:
-    - "$ref": "#/definitions/commaSeperatedValues"
-    - type: array
-      contains:
-        type: string
-      uniqueItems: true
-  
-  title:
-    "$id": "#/properties/title"
-    "$comment": "dct:title"
-    title: Title
-    description: Name of the dataset limited to 80 characters. It should provide a
-      short description of the dataset and be unique across the gateway. If your title
-      is not unique, please add a prefix with your organisation name or identifier
-      to differentiate it from other datasets within the Gateway. Please avoid acronyms
-      wherever possible. Good titles should summarise the content of the dataset and
-      if relevant, the region the dataset covers.
-    allOf:
-    - "$ref": "#/definitions/eightyCharacters"
-    examples:
-    - North West London COVID-19 Patient Level Situation Report
-  
-  abstract:
-    "$id": "#/properties/abstract"
-    "$comment": "dct:abstract"
-    title: Abstract
-    description: 'Provide a clear and brief descriptive signpost for researchers
-        who are searching for data that may be relevant to their research. The abstract
-        should allow the reader to determine the scope of the data collection and
-        accurately summarise its content. The optimal length is one paragraph (limited
-        to 255 characters) and effective abstracts should avoid long sentences and
-        abbreviations where possible. Note: Researchers will view Titles and Abstracts
-        when searching for datasets and choosing whether to explore their content
-        further. Abstracts must be different from the full description for a dataset.'
-    allOf:
-    - "$ref": "#/definitions/abstractText"
-    examples:
-    - CPRD Aurum contains primary care data contributed by General Practitioner
-      (GP) practices using EMIS Web® including patient registration information
-      and all care events that GPs have chosen to record as part of their usual
-      medical practice.
-  
-  publisher:
-    "$id": "#/properties/publisher"
-    "$comment": dct:publisher Conforms to spec, but this MAY be an an object of organisation
-    title: Publisher
-    description: 'Completion Notes: This is the organisation responsible for running
-      or supporting the data access request process, as well as publishing and
-      maintaining the metadata. In most this will be the same as the HDR UK Organisation
-      (Hub or Alliance Member). However, in some cases this will be different
-      i.e. Tissue Directory are an HDR UK Gateway organisation but coordinate
-      activities across a number of data publishers i.e. Cambridge Blood and Stem
-      Cell Biobank.'
-    allOf:
-    - "$ref": "#/definitions/eightyCharacters"
-    examples:
-    - Cambridge Blood and Stem Cell Biobank
-  
-  contactPoint:
-    "$id": "#/properties/contactPoint"
-    "$comment": dcat:contactPoint
-    title: Contact Point
-    description: 'Please provide a valid email address that can be used to coordinate
-      data access requests with the publisher. Organisations are expected to provide
-      a dedicated email address associated with the data access request process.
-      Notes: An employee’s email address can only be provided on a temporary basis
-      and if one is provided an explicit consent must be obtained for this purpose.'
-    allOf:
-    - "$ref": "#/definitions/emailAddress"
-  
-  keywords:
-    "$id": "#/properties/keywords"
-    "$comment": dcat:keyword Conforms to spec, but this MAY be an array of strings
-    title: Keywords
-    description: 'Please provide relevant and specific keywords that can improve
-      the SEO of your dataset as a comma separated list. Notes: Onboarding portal
-      will suggest keywords based on title, abstract and description. We are compiling
-      a standardised list of keywords and synonyms across datasets to make filtering
-      easier for users.'
-    anyOf:
-    - "$ref": "#/definitions/commaSeperatedValues"
-    - type: array
-      contains:
-        type: string
-      uniqueItems: true
-      minItems: 1
-  
-  doi:
-    "$id": "#/properties/doi"
-    title: Digital Object Identifier
-    description: 'Registered datasets should either have a Digital Object Identifier
-      (DOI) or be working towards obtaining one. If a DOI is available, please
-      provide the DOI. If a DOI has not been created for the dataset, please provide
-      a default value: “In Progress” whilst you create your DOI. You can either
-      use the HDR UK Onboarding Portal (HOP) to mint a DOI for your dataset or
-      your chosen alternative means. Note: This is not the DOI of the publication(s)
-      associated with the dataset.'
-    anyOf:
-    - type: string
-      enum:
-      - In Progress
-    - "$ref": "#/definitions/doi"
-    examples:
-    - 10.3399/bjgp17X692645
-
-  accessRights:
-    "$id": "#/properties/accessRights"
-    "$comment": 'FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality
-      is 1:*'
-    title: The accessRights schema
-    description: The URL of a webpage where the data access request process and/or
-      guidance is provided. If there is more than one access process i.e. industry
-      vs academic please provide both. If such a resource or the underlying process
-      doesn’t exist, please provide “In Progress”, until both the process and the
-      documentation are ready.
-    anyOf:
-    - type: string
-      pattern: "^In Progress$"
-    - type: string
-      format: uri
-    - type: array
-      items:
-        type: string
+  summary:
+    id:
+      "$id": "#/properties/summary/id"
+      title: Dataset identifier
+      description: Dataset identifier (UUIDv4 format)
+      allOf:
+      - "$ref": "#/definitions/uuidv4"
+    identifiers:
+      "$id": "#/properties/summary/identifier"
+      "$comment": 'FIX SPEC: Conforms to spec, but this MAY be an array of strings.'
+      anyOf:
+      - type: string
+      - type: array
+        items:
+          type: string
+      title: Local dataset identifiers
+      description: Local dataset identifier
+    name:
+      "$id": "#/properties/summary/name"
+      "$comment": "using name from schema.org, title is reserved word in json schema"
+      type: string
+      minLength: 2
+      maxLength: 80
+      title: title
+      description: Name of the dataset limited to 80 characters. It should provide a
+        short description of the dataset and be unique across the gateway. If your title
+        is not unique, please add a prefix with your organisation name or identifier
+        to differentiate it from other datasets within the Gateway. Please avoid acronyms
+        wherever possible. Good titles should summarise the content of the dataset and
+        if relevant, the region the dataset covers.
+    abstract:
+      "$id": "#/properties/summary/abstract"
+      type: string
+      minLength: 5
+      maxLength: 255
+      title: Dataset abstract
+      description: Provide a clear and brief descriptive signpost for researchers who
+        are searching for data that may be relevant to their research. The abstract
+        should allow the reader to determine the scope of the data collection and accurately
+        summarise its content. The optimal length is one paragraph (limited to 255 characters)
+        and effective abstracts should avoid long sentences and abbreviations where
+        possible
+    publisher:
+      "$id": "#/properties/summary/publisher"
+      "$comment": Conforms to spec, but this MAY be an an object of organisation
+      type: string
+      minLength: 2
+      maxLength: 80
+      title: Dataset publisher
+      description: This is the organisation responsible for running or supporting the
+        data access request process, as well as publishing and maintaining the metadata.
+        In most this will be the same as the HDR UK Organisation (Hub or Alliance Member).
+        However, in some cases this will be different i.e. Tissue Directory are an HDR
+        UK Gateway organisation but coordinate activities across a number of data publishers
+        i.e. Cambridge Blood and Stem Cell Biobank.
+    contactPoint:
+      "$id": "#/properties/summary/contactPoint"
+      type: string
+      format: email
+      title: The contactPoint schema  
+      description: An explanation about the purpose of this instance.
+    keywords:
+      "$id": "#/properties/summary/keywords"
+      "$comment": Conforms to spec, but this MAY be an array of strings
+      anyOf:
+        - type: string
+          pattern: "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+        - type: array
+          items:
+            type: string
+            pattern: "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+      type: string
+      pattern: "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+      title: The keywords schema
+      description: An explanation about the purpose of this instance.
+    doiName:
+      "$id": "#/properties/summary/doiName"
+      anyOf:
+      - type: string
+        enum:
+        - In Progress
+      - type: string
+        pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
+        title: Digital Object Identifier
+        description: All HDR UK registered datasets should either have a Digital Object
+            Identifier (DOI) or be working towards obtaining one. If a DOI is available,
+            please provide the DOI.         
+    accessRights:
+      "$id": "#/properties/accessRights"
+      "$comment": 'FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality'
+      anyOf:
+      - type: string
+        pattern: "^In Progress$"
+      - type: string
         format: uri
-  
+      - type: array
+        items:
+          type: string
+          format: uri
+      title: The accessRights schema
+      description: The URL of a webpage where the data access request process and/or
+        guidance is provided. If there is more than one access process i.e. industry
+        vs academic please provide both. If such a resource or the underlying process
+        doesn’t exist, please provide “In Progress”, until both the process and the
+        documentation are ready.
   group:
     "$id": "#/properties/group"
     "$comment": Conforms to spec, but this MAY be an array of groups
+    type: string
     title: The group schema
     description: An explanation about the purpose of this instance.
-    type: string
-  
   description:
     "$id": "#/properties/description"
-    title: The description schema
-    description: A free-text account of the record. An html account of the data that
-      provides context and scope of the data (limited to 50,000 characters) and/or
-      a resolvable URL that describes the dataset.
     anyOf:
     - type: string
       minLength: 5
       maxLength: 50000
     - type: string
       format: uri
-  
+    title: The description schema
+    description: A free-text account of the record. An html account of the data that
+      provides context and scope of the data (limited to 50,000 characters) and/or
+      a resolvable URL that describes the dataset.
   media:
     "$id": "#/properties/media"
     "$comment": 'FIXME: Conforms to spec, but this SHOULD to be an array of URIs as
       cardinality 0:*'
-    title: The media schema
-    description: Please provide any media associated with the Gateway Organisation
-      using a valid URI. This is an opportunity to provide additional context that
-      could be useful for researchers wanting to undestand more about the dataset
-      and its relevance to their research question. The following formats will be
-      accepted .jpg, .png or .svg, .pdf, .xslx or .docx.
     anyOf:
     - type: string
       format: uri
@@ -205,13 +162,15 @@ properties:
       items:
         type: string
         format: uri
-  
+    title: The media schema
+    description: Please provide any media associated with the Gateway Organisation
+      using a valid URI. This is an opportunity to provide additional context that
+      could be useful for researchers wanting to undestand more about the dataset
+      and its relevance to their research question. The following formats will be
+      accepted .jpg, .png or .svg, .pdf, .xslx or .docx.
   purpose:
     "$id": "#/properties/purpose"
     "$comment": 'FIXME: Mandatory, but cardinality 0:* Possibly deprecate.'
-    title: The purpose schema
-    description: Pleases indicate the purpose(s) that the dataset was collected. Multiple
-      purposes may be provided
     anyOf:
     - type: string
       enum:
@@ -233,13 +192,12 @@ properties:
         - Audit
         - Administrative
         - Financial
-  
+    title: The purpose schema
+    description: Pleases indicate the purpose(s) that the dataset was collected. Multiple
+      purposes may be provided
   source:
     "$id": "#/properties/source"
     "$comment": 'FIXME: Mandatory, but cardinality 0:* Possibly deprecate.'
-    title: The source schema
-    description: Pleases indicate the source(s) that the dataset was collected. Multiple
-      source(s) may be provided
     anyOf:
     - type: string
       enum:
@@ -259,14 +217,12 @@ properties:
         - Paper Based
         - Freetext Nlp
         - Machine Generated
-  
-  
+    title: The source schema
+    description: Pleases indicate the source(s) that the dataset was collected. Multiple
+      source(s) may be provided
   setting:
     "$id": "#/properties/setting"
     "$comment": 'FIXME: Mandatory, but cardinality 0:*. Possibly deprecate.'
-    title: The setting schema
-    description: Pleases indicate the setting(s) where data was collected. Multiple
-      settings may be provided.
     anyOf:
     - type: string
       enum:
@@ -294,25 +250,22 @@ properties:
         - Home
         - Private
         - Pharmacy
-  
+    title: The setting schema
+    description: Pleases indicate the setting(s) where data was collected. Multiple
+      settings may be provided.
   releaseDate:
     "$id": "#/properties/releaseDate"
-    title: The releaseDate schema
-    description: An explanation about the purpose of this instance.
     type: string
     format: date-time
-  
+    title: The releaseDate schema
+    description: An explanation about the purpose of this instance.
   accessRequestCost:
     "$id": "#/properties/accessRequestCost"
+    type: string
     title: The accessRequestCost schema
     description: An explanation about the purpose of this instance.
-    type: string
-  
   accessRequestDuration:
     "$id": "#/properties/accessRequestDuration"
-    title: The accessRequestDuration schema
-    description: Please provide an indication of the typical processing times based
-      on the types of requests typically received.
     type: string
     enum:
     - "<1 Week"
@@ -322,22 +275,20 @@ properties:
     - 2-6 Months
     - ">6 Months"
     - Other
-  
+    title: The accessRequestDuration schema
+    description: Please provide an indication of the typical processing times based
+      on the types of requests typically received.
   accessEnvironment:
     "$id": "#/properties/accessEnvironment"
-    title: The accessEnvironment schema
-    description: Please provide a brief description of the data access environment
-      that is currently available to researchers.
     type: string
     minLength: 5
     maxLength: 5000
-  
+    title: The accessEnvironment schema
+    description: Please provide a brief description of the data access environment
+      that is currently available to researchers.
   usageRestrictions:
     "$id": "#/properties/usageRestrictions"
     "$comment": 'FIXME: Missing from Onboarding tool, so not captured'
-    title: The usageRestrictions schema
-    description: Please provide a description of any usage restrictions of key terms
-      and conditions under which access to the dataset is provided.
     anyOf:
     - type: string
       minLength: 5
@@ -345,23 +296,20 @@ properties:
     - type: string
       enum:
       - In Progress
-  
+    title: The usageRestrictions schema
+    description: Please provide a description of any usage restrictions of key terms
+      and conditions under which access to the dataset is provided.
   dataController:
     "$id": "#/properties/dataController"
+    type: string
+    minLength: 5
+    maxLength: 5000
     title: The dataController schema
     description: Data Controller means a person/entity who (either alone or jointly
       or in common with other persons/entities) determines the purposes for which
       and the way any Data Subject data, specifically personal data or are to be processed.
-    type: string
-    minLength: 5
-    maxLength: 5000
-  
   dataProcessor:
     "$id": "#/properties/dataProcessor"
-    title: The dataProcessor schema
-    description: A Data Processor, in relation to any Data Subject data, specifically
-      personal data, means any person/entity (other than an employee of the data controller)
-      who processes the data on behalf of the data controller.
     anyOf:
     - type: string
       minLength: 5
@@ -369,20 +317,19 @@ properties:
     - type: string
       enum:
       - Not Applicable
-  
+    title: The dataProcessor schema
+    description: A Data Processor, in relation to any Data Subject data, specifically
+      personal data, means any person/entity (other than an employee of the data controller)
+      who processes the data on behalf of the data controller.
   license:
     "$id": "#/properties/license"
+    type: string
     title: The license schema
     description: An explanation about the purpose of this instance.
-    type: string
-  
   derivedDatasets:
     "$id": "#/properties/derivedDatasets"
     "$comment": 'FIXME: Conforms to spec, but this SHOULD to be an array of datasets
       as cardinality 0:*'
-    title: The derivedDatasets schema
-    description: Indicate if derived datasets or predefined extracts are available
-      and the type of derivation available.
     anyOf:
     - type: string
       format: uri
@@ -394,30 +341,38 @@ properties:
       enum:
       - Not Known
       - Not Available
-  
+    title: The derivedDatasets schema
+    description: Indicate if derived datasets or predefined extracts are available
+      and the type of derivation available.
   linkedDataset:
     "$id": "#/properties/linkedDataset"
     "$comment": 'FIXME: If linked $title must start with ''Linked''. FIXME: Conforms
       to spec, but this SHOULD to be an array of datasets as cardinality 0:*'
+    anyOf:
+    - type: string
+      format: uri
+    - type: array
+      items:
+        type: string
+        format: uri
+    - type: string
+      enum:
+      - Not Known
+      - Not Available
     title: The linkedDataset schema
     description: If applicable, please provide the DOI of other datasets that have
       previously been linked to this dataset and their availability. If no DOI is
       available, please provide the title of the datasets that can be linked, where
       possible using the same title of a dataset previously onboarded.
+  linkageOpportunity:
+    "$id": "#/properties/linkageOpportunity"
     anyOf:
     - type: string
-      format: uri
-    - type: array
-      items:
-        type: string
-        format: uri
     - type: string
       enum:
       - Not Known
       - Not Available
-  
-  linkageOpportunity:
-    "$id": "#/properties/linkageOpportunity"
+    type: string
     title: The linkageOpportunity schema
     description: If applicable, please indicate if there is the opportunity to link
       this dataset to additional data sources. If possible, please describe the data
@@ -425,193 +380,283 @@ properties:
       postcode could be used to link to open datasets such as air pollution or deprivation
       indices. In addition, please describe the restricted data elements that cannot
       be used to link to other datasets.
-    anyOf:
-    - type: string
-    - type: string
-      enum:
-      - Not Known
-      - Not Available
-    type: string
-  
   geographicCoverage:
     "$id": "#/properties/geographicCoverage"
     "$comment": 'FIXME: Update to geoname pattern'
-    title: The geographicCoverage schema
-    description: The geographical area covered by the dataset.
     type: string
     format: uri
+    title: The geographicCoverage schema
+    description: The geographical area covered by the dataset.
     default: ''
     examples:
     - GB
-  
   periodicity:
     "$id": "#/properties/periodicity"
+    type: string
+    enum:
+    - Static
+    - Annual
+    - Biennial
+    - Quaterly
+    - Bimonthly
+    - Monthly
+    - Biweekly
+    - Daily
+    - Irregular
+    - Continious
     title: The periodicity schema
     description: The frequency at which dataset is published.
-    "$ref": "#/definitions/periodicity"
-  
   datasetEndDate:
     "$id": "#/properties/datasetEndDate"
+    type: string
+    format: date
     title: The datasetEndDate schema
     description: The end of the time period that the dataset provides coverage for.
-    type: string
-    format: date
-  
   datasetStartDate:
     "$id": "#/properties/datasetStartDate"
-    title: The datasetStartDate schema
-    description: The start of the time period that the dataset provides coverage for.
     type: string
     format: date
-    
-  
+    title: The datasetStartDate schema
+    description: The start of the time period that the dataset provides coverage for.
   jurisdiction:
     "$id": "#/properties/jurisdiction"
     "$comment": 'FIXME: Add ISO 3166-2 Subdivision code pattern'
+    type: string
+    pattern: "^[A-Z]{2}(-[A-Z]{2,3})?$"
     title: The jurisdiction schema
     description: Please use country code from ISO 3166-1 country codes and the associated
       ISO 3166-2 for regions, cities, states etc. for the country/state under whose
       laws the data subjects’ data is collected, processed and stored.
-    type: string
-    pattern: "^[A-Z]{2}(-[A-Z]{2,3})?$"
-  
   populationType:
     "$id": "#/properties/populationType"
     "$comment": 'FIXME: Check against SNOMED-CT TERMS. Conforms to spec but MAY be
       array of strings'
+    anyOf:
+    - type: string
+    - type: array
+      items:
+        type: string
     title: The populationType schema
     description: Please provide a valid SNOMED CT concept that describes the measure
       within the dataset i.e. participants in a study, modality, or images with certain
       characteristics.
-    anyOf:
-    - type: string
-    - type: array
-      items:
-        type: string
-    
   disabmiguatingDescription:
     "$id": "#/properties/disabmiguatingDescription"
-    "$comment": 'FIXME: MDC is not populated with this value'
+    "$comment": 'FIXME: Rename MDC response to ageRange according to spec'
+    type: string
+    pattern: "\\d{1,3}-\\d{1,3}"
     title: The disabmiguatingDescription schema
     description: If SNOMED CT term does not provide sufficient detail, please provide
       a description that disambiguates the population type.
-    type: string
-    
-  
   statisticalPopulation:
     "$id": "#/properties/statisticalPopulation"
     "$comment": 'FIXME: Spec calls this Measured Value'
-    title: The statisticalPopulation schema
-    description: An explanation about the purpose of this instance.
     anyOf:
     - type: string
     - type: array
       items:
         type: string
-    
-  
+    title: The statisticalPopulation schema
+    description: An explanation about the purpose of this instance.
   ageBand:
     "$id": "#/properties/ageBand"
     "$comment": 'FIXME: Rename MDC response to ageRange according to spec'
+    type: string
+    pattern: "\\d{1,3}-\\d{1,3}"
     title: The ageBand schema
     description: Please indicate the age range in whole years of participants in the
       dataset. Please provide range in the following format ‘[min age] – [max age]’
       where both the minimum and maximum are whole numbers (integers).
-    "$ref": "#/definitions/numericRange"
-  
   physicalSampleAvailability:
     "$id": "#/properties/physicalSampleAvailability"
-    "$comment": Conforms to spec, but this MAY be an array of strings
+    type: string
+    enum:
+    - Not Available
+    - Bone Marrow
+    - Cancer Cell Lines
+    - Core Biopsy
+    - CDNA/MRNA
+    - DNA
+    - Faeces
+    - Immortalized Cel Lines
+    - MicroRNA
+    - Peripheral Blood Cells
+    - Plasma
+    - PM Tissue
+    - Primary Cells
+    - RNA
+    - Saliva
+    - Serum
+    - Swabs
+    - Tissue
+    - Urine
+    - Whole Blood
+    - Availability To Be Confirmed
     title: The physicalSampleAvailability schema
     description: Availability of physical samples associated with the dataset. If
       samples are available, please indicate the types of samples that are available.
-    anyOf:
-    - "$ref": "#/definitions/physicalSampleAvailability"
-    - type: array
-      items:
-        "$ref": "#/definitions/physicalSampleAvailability"
     default: ''
     examples:
     - Not Available
-  
   conformsTo:
+    "$id": "#/properties/conformsTo"
+    type: string
+    enum:
+    - HL7 FHIR
+    - HL7 V2
+    - HL7 CDA
+    - HL7 CCOW
+    - LOINC
+    - DICOM
+    - I2B2
+    - IHE
+    - OMOP
+    - OPENEHR
+    - SENTINEL
+    - PCORNET
+    - LOCAL
+    - OTHER
     title: The conformsTo schema
     description: An explanation about the purpose of this instance.
-    "$id": "#/properties/conformsTo"
-    "$ref": "#/definitions/conformsTo"
-  
   controlledVocabulary:
     "$id": "#/properties/controlledVocabulary"
     "$comment": 'FIXME: Confroms to spec, but MAY be a list of strings'
+    anyOf:
+    - type: string
+      enum:
+      - LOCAL
+      - OPCS4
+      - READ
+      - SNOMED CT
+      - SNOMED RT
+      - DM+D
+      - NHS NATIONAL CODES
+      - ODS
+      - LOINC
+      - ICD10
+      - ICD10CM
+      - ICD10PCS
+      - ICD9CM
+      - ICD9
+      - ICDO3
+      - AMT
+      - APC
+      - ATC
+      - CIEL
+      - HPO
+      - CPT4
+      - DPD
+      - DRG
+      - HEMONIC
+      - JMDC
+      - KCD7
+      - MULTUM
+      - NAACCR
+      - NDC
+      - NDFRT
+      - OXMIS
+      - RXNORM
+      - RXNORM EXTENSION
+      - SPL
+      - OTHER
+    - type: array
+      items:
+        type: string
+        enum:
+        - LOCAL
+        - OPCS4
+        - READ
+        - SNOMED CT
+        - SNOMED RT
+        - DM+D
+        - NHS NATIONAL CODES
+        - ODS
+        - LOINC
+        - ICD10
+        - ICD10CM
+        - ICD10PCS
+        - ICD9CM
+        - ICD9
+        - ICDO3
+        - AMT
+        - APC
+        - ATC
+        - CIEL
+        - HPO
+        - CPT4
+        - DPD
+        - DRG
+        - HEMONIC
+        - JMDC
+        - KCD7
+        - MULTUM
+        - NAACCR
+        - NDC
+        - NDFRT
+        - OXMIS
+        - RXNORM
+        - RXNORM EXTENSION
+        - SPL
+        - OTHER
     title: The controlledVocabulary schema
     description: List any relevant terminologies / ontologies / controlled vocabularies,
       such as ICD 10 Codes, NHS Data Dictionary National Codes or SNOMED CT International,
-      that are being used by the dataset.    
-    anyOf:
-    - "$ref": "#/definitions/controlledVocabulary"
-    - type: array
-      items:
-        "$ref": "#/definitions/controlledVocabulary"
+      that are being used by the dataset.
     default: ''
     examples:
     - See ConformsTo
-  
   language:
     "$id": "#/properties/language"
     "$comment": 'FIXME: Conforms to spec, but may be a list of strings given cardinality
       1:*. Validate against external list of languages. Resources defined by the Library
       of Congress (ISO 639-1, ISO 639-2) SHOULD be used.'
-    title: The language schema
-    description: This should list all the languages in which the dataset metadata
-      and underlying data is made available.
     anyOf:
     - type: string
     - type: array
       items:
         type: string
-  
+    title: The language schema
+    description: This should list all the languages in which the dataset metadata
+      and underlying data is made available.
   format:
     "$id": "#/properties/format"
     "$comment": 'FIXME: Conforms to spec, but may be a list of strings given cardinality
       1:*. Validate against external list of formats, e.g. https://www.iana.org/assignments/media-types/media-types.xhtml'
-    title: The format schema
-    description: If multiple formats are available please specify.
     anyOf:
     - type: string
     - type: array
       items:
         type: string
-  
+    title: The format schema
+    description: If multiple formats are available please specify.
   fileSize:
     "$id": "#/properties/fileSize"
+    type: string
     title: The fileSize schema
     description: An explanation about the purpose of this instance.
-    type: string
     default: ''
     examples:
     - 301MB
-  
   creator:
     "$id": "#/properties/creator"
+    type: string
     title: The creator schema
     description: Please provide the text that you would like included as part of any
       citation that credits this dataset. This is typically just the name of the publisher.
       No employee details should be provided.
-    type: string
-  
   citations:
     "$id": "#/properties/citations"
     "$comment": 'FIXME: Conforms to spec, but may be a list of citation strings'
-    title: The citations schema
-    description: Please provide the keystone paper associated with the dataset. Also
-      include a list of known citations, if available and should be links to existing
-      resources where the dataset has been used or referenced.
     anyOf:
     - type: string
     - type: array
       items:
         type: string
-
+    title: The citations schema
+    description: Please provide the keystone paper associated with the dataset. Also
+      include a list of known citations, if available and should be links to existing
+      resources where the dataset has been used or referenced.
+  
 definitions:
   uuidv4:
     type: string

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -34,7 +34,7 @@ additionalProperties: true
 properties:
   id:
     "$id": "#/properties/id"
-    title: Dataset Identifier
+    title: Identifier
     description: Dataset identifier (UUIDv4 format)
     allOf:
     - "$ref": "#/definitions/uuidv4"
@@ -67,7 +67,7 @@ properties:
   
   abstract:
     "$id": "#/properties/abstract"
-    "$comment": dct:abstract
+    "$comment": "dct:abstract"
     title: Abstract
     description: 'Provide a clear and brief descriptive signpost for researchers
         who are searching for data that may be relevant to their research. The abstract

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -5,13 +5,11 @@ title: HDR UK Dataset
 description: HDR UK Dataset Schema
 
 required:
-- id
-- identifiers
+- identifier
 - title
 - abstract
 - publisher
 - contactPoint
-- accessRights
 - accessRequestCost
 - dataController
 - license
@@ -26,112 +24,132 @@ required:
 - language
 - format
 - creator
-- doi
 - usageRestrictions
-
 additionalProperties: true
-
 properties:
   summary:
-    id:
-      "$id": "#/properties/summary/id"
-      title: Dataset identifier
-      description: Dataset identifier (UUIDv4 format)
-      allOf:
-      - "$ref": "#/definitions/uuidv4"
-    identifiers:
+    identifier:
       "$id": "#/properties/summary/identifier"
-      "$comment": 'FIX SPEC: Conforms to spec, but this MAY be an array of strings.'
+      title: Dataset identifier
+      "$comment": "http://purl.org/dc/terms/identifier",
+      examples:
+        - ["226fb3f1-4471-400a-8c39-2b66d46a39b6"],
+      description: System dataset identifier
       anyOf:
+      - "$ref": "#/definitions/uuidv4"
       - type: string
-      - type: array
-        items:
-          type: string
-      title: Local dataset identifiers
-      description: Local dataset identifier
+        format: uri
+    alternate-identifiers:
+      "$id": "#/properties/summary/alternate-identifiers"
+      "$comment": 'DATA-CITE alternate-identifiers used. Note, will support comma separated list for backwards compatibility with other systems'
+      title: Alternate dataset identifiers
+      description: Alternate dataset identifiers or local identifiers
+      anyOf:
+        - "$ref": "#/properties/summary/commaSeparatedValues"
+        - type: array
+          contains:
+            type: string
+          uniqueItems: true
+          minItems: 1
     title:
       "$id": "#/properties/summary/title"
       "$comment": "title is reserved word in json schema"
       type: string
-      minLength: 2
-      maxLength: 80
-      title: title
+      title: Title
       description: Title of the dataset limited to 80 characters. It should provide a
         short description of the dataset and be unique across the gateway. If your title
         is not unique, please add a prefix with your organisation name or identifier
         to differentiate it from other datasets within the Gateway. Please avoid acronyms
         wherever possible. Good titles should summarise the content of the dataset and
         if relevant, the region the dataset covers.
+       examples:
+        - ["North West London COVID-19 Patient Level Situation Report"]
+       allOf:
+        - "$ref": "#/definitions/eightycharacters"
     abstract:
       "$id": "#/properties/summary/abstract"
-      type: string
-      minLength: 5
-      maxLength: 255
-      title: Dataset abstract
+      title: Dataset Abstract
       description: Provide a clear and brief descriptive signpost for researchers who
         are searching for data that may be relevant to their research. The abstract
         should allow the reader to determine the scope of the data collection and accurately
         summarise its content. The optimal length is one paragraph (limited to 255 characters)
         and effective abstracts should avoid long sentences and abbreviations where
         possible
+      "$comment": dct:abstract
+       examples:
+        - CPRD Aurum contains primary care data contributed by General Practitioner
+          (GP) practices using EMIS Web® including patient registration information
+          and all care events that GPs have chosen to record as part of their usual
+          medical practice.
+       allOf:
+        - "$ref": "#/definitions/abstractText"
     publisher:
       "$id": "#/properties/summary/publisher"
-      "$comment": Conforms to spec, but this MAY be an an object of organisation
-      type: string
-      minLength: 2
-      maxLength: 80
-      title: Dataset publisher
+      "$comment": dct:publisher. Conforms to spec, but this MAY be an an object of organisation
+      title: Dataset Publisher
+      default: Defaulted to the primary organisation of the registered user in metadata exchange
+      examples:
+        - Cambridge Blood and Stem Cell Biobank
       description: This is the organisation responsible for running or supporting the
         data access request process, as well as publishing and maintaining the metadata.
         In most this will be the same as the HDR UK Organisation (Hub or Alliance Member).
         However, in some cases this will be different i.e. Tissue Directory are an HDR
         UK Gateway organisation but coordinate activities across a number of data publishers
         i.e. Cambridge Blood and Stem Cell Biobank.
-    contactPoint:
+      allOf:
+        - "$ref": "#/definitions/eightycharacters"
+    contact-point:
       "$id": "#/properties/summary/contactPoint"
-      type: string
-      format: email
-      title: The contactPoint schema  
-      description: An explanation about the purpose of this instance.
+      title: Contact Point
+      "$comment": dcat:contactPoint
+      default: Defaulted to the contact point of the primary organisation of the user
+      examples:
+       - SAILDatabank@swansea.ac.uk
+      description: 'Please provide a valid email address that can be used to coordinate
+          data access requests with the publisher. Organisations are expected to provide
+          a dedicated email address associated with the data access request process.
+          Notes: An employee’s email address can only be provided on a temporary basis
+          and if one is provided an explicit consent must be obtained for this purpose.'
+      allOf:
+       - "$ref": "#/definitions/email"
     keywords:
       "$id": "#/properties/summary/keywords"
-      "$comment": Conforms to spec, but this MAY be an array of strings
+      "$comment": dcat:keyword. May be an array of strings or comma seperated list.
+      title: Keywords
+      description: 'Please provide relevant and specific keywords that can improve
+          the SEO of your dataset as a comma separated list. Notes: Onboarding portal
+          will suggest keywords based on title, abstract and description. We are compiling
+          a standardised list of keywords and synonyms across datasets to make filtering
+          easier for users.'
       anyOf:
-        - type: string
-          pattern: "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+        - "$ref": "#/properties/summary/commaSeparatedValues"
         - type: array
-          items:
+          contains:
             type: string
-            pattern: "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
-      type: string
-      pattern: "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
-      title: The keywords schema
-      description: An explanation about the purpose of this instance.
-    doi:
-      "$id": "#/properties/summary/doi"
-      anyOf:
-      - type: string
-        enum:
-        - In Progress
-      - type: string
-        pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
-        title: Digital Object Identifier
-        description: All HDR UK registered datasets should either have a Digital Object
-            Identifier (DOI) or be working towards obtaining one. If a DOI is available,
-            please provide the DOI.         
+          uniqueItems: true
+          minItems: 1
+    doiName:
+      "$id": "#/properties/summary/doiName"
+      title: Digital Object Identifier
+      description: All HDR UK registered datasets should either have a Digital Object
+          Identifier (DOI) or be working towards obtaining one. If a DOI is available,
+          please provide the DOI.
+      allOf:
+        - "$ref": "#/definitions/doi"
+      "$comment": 'Vocabulary: DOI Data Dictionary '
+      examples:
+        - 10.3399/bjgp17X692645
     accessRights:
       "$id": "#/properties/accessRights"
       "$comment": 'FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality'
       anyOf:
-      - type: string
-        pattern: "^In Progress$"
       - type: string
         format: uri
       - type: array
         items:
           type: string
           format: uri
-      title: The accessRights schema
+      title: Access Rights
       description: The URL of a webpage where the data access request process and/or
         guidance is provided. If there is more than one access process i.e. industry
         vs academic please provide both. If such a resource or the underlying process
@@ -660,40 +678,40 @@ properties:
     description: Please provide the keystone paper associated with the dataset. Also
       include a list of known citations, if available and should be links to existing
       resources where the dataset has been used or referenced.
-  
+
 definitions:
   uuidv4:
     type: string
     pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
     minLength: 36
     maxLength: 36
-  
+
   eightyCharacters:
     type: string
     minLength: 2
     maxLength: 80
-  
+
   abstractText:
     type: string
     minLength: 5
     maxLength: 255
-  
+
   emailAddress:
     type: string
     format: email
-  
+
   commaSeparatedValues:
     type: string
     pattern: "([^,]+)"
-  
+
   numericRange:
     type: string
     pattern: "\\d{1,3}-\\d{1,3}"
-  
+
   doi:
     type: string
     pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
-  
+
   controlledVocabulary:
     type: string
     enum:
@@ -732,7 +750,7 @@ definitions:
     - 'RXNORM EXTENSION'
     - 'SPL'
     - 'OTHER'
-  
+
   conformsTo:
     type: string
     enum:
@@ -751,7 +769,7 @@ definitions:
     - 'CDISC'
     - 'LOCAL'
     - 'OTHER'
-  
+
   physicalSampleAvailability:
     type: string
     enum:
@@ -776,7 +794,7 @@ definitions:
     - 'URINE'
     - 'WHOLE BLOOD'
     - 'AVAILABILITY TO BE CONFIRMED'
-  
+
   periodicity:
     type: string
     enum:

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -111,7 +111,7 @@ properties:
           Notes: An employee’s email address can only be provided on a temporary basis
           and if one is provided an explicit consent must be obtained for this purpose.'
       allOf:
-       - "$ref": "#/definitions/email"
+       - "$ref": "#/definitions/emailAddress"
     keywords:
       "$id": "#/properties/summary/keywords"
       "$comment": dcat:keyword. May be an array of strings or comma seperated list.

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -45,7 +45,7 @@ properties:
       title: Alternate dataset identifiers
       description: Alternate dataset identifiers or local identifiers
       anyOf:
-        - "$ref": "#/properties/summary/commaSeparatedValues"
+        - "$ref": "#/definitions/commaSeparatedValues"
         - type: array
           contains:
             type: string
@@ -65,7 +65,7 @@ properties:
       examples:
         - ["North West London COVID-19 Patient Level Situation Report"]
       allOf:
-        - "$ref": "#/definitions/eightycharacters"
+        - "$ref": "#/definitions/eightyCharacters"
     abstract:
       "$id": "#/properties/summary/abstract"
       title: Dataset Abstract
@@ -97,7 +97,7 @@ properties:
         UK Gateway organisation but coordinate activities across a number of data publishers
         i.e. Cambridge Blood and Stem Cell Biobank.
       allOf:
-        - "$ref": "#/definitions/eightycharacters"
+        - "$ref": "#/definitions/eightyCharacters"
     contact-point:
       "$id": "#/properties/summary/contactPoint"
       title: Contact Point
@@ -122,7 +122,7 @@ properties:
           a standardised list of keywords and synonyms across datasets to make filtering
           easier for users.'
       anyOf:
-        - "$ref": "#/properties/summary/commaSeparatedValues"
+        - "$ref": "#/definitions/commaSeparatedValues"
         - type: array
           contains:
             type: string

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -31,9 +31,9 @@ properties:
     identifier:
       "$id": "#/properties/summary/identifier"
       title: Dataset identifier
-      "$comment": "http://purl.org/dc/terms/identifier",
+      "$comment": "http://purl.org/dc/terms/identifier"
       examples:
-        - ["226fb3f1-4471-400a-8c39-2b66d46a39b6"],
+        - ["226fb3f1-4471-400a-8c39-2b66d46a39b6"]
       description: System dataset identifier
       anyOf:
       - "$ref": "#/definitions/uuidv4"
@@ -62,9 +62,9 @@ properties:
         to differentiate it from other datasets within the Gateway. Please avoid acronyms
         wherever possible. Good titles should summarise the content of the dataset and
         if relevant, the region the dataset covers.
-       examples:
+      examples:
         - ["North West London COVID-19 Patient Level Situation Report"]
-       allOf:
+      allOf:
         - "$ref": "#/definitions/eightycharacters"
     abstract:
       "$id": "#/properties/summary/abstract"
@@ -76,12 +76,12 @@ properties:
         and effective abstracts should avoid long sentences and abbreviations where
         possible
       "$comment": dct:abstract
-       examples:
+      examples:
         - CPRD Aurum contains primary care data contributed by General Practitioner
           (GP) practices using EMIS Web® including patient registration information
           and all care events that GPs have chosen to record as part of their usual
           medical practice.
-       allOf:
+      allOf:
         - "$ref": "#/definitions/abstractText"
     publisher:
       "$id": "#/properties/summary/publisher"


### PR DESCRIPTION
# RFC D01: Dataset v2 - Summary Section
## Summary & Motivation:
This RFC introduces a new list of changes to allow the dataset metadata specification to be upgraded to the next version (v2.0.0). The specification upgrade is aimed to improve the consistency of the metadata supplied by the data custodians and streamline the process.

### Authors:
- A. Milward (MetadataWorks)
- D. Milward (MetadataWorks)
- S. Varma (HDR UK)

## Detailed List Of Changes:
This RFC is limited to the summary section of the new specification which is listed below:

**Required Properties**:
- **`identifier`**:
  - Moved UUIDv4 string pattern into a separate definition called `uuidv4`
  - Added any of url or uuid 
- **`title`**:
  - Moved 2-80 character limit to a new definition called `eightyCharacters`
  - Added examples
- **`abstract`**:
  - Moved 5-255 character limit to a new definition called `abstractText`
  - Updated property description
  - Added examples
- **`publisher`**:
  - Moved 2-80 character limit to reuse new definition called `eightyCharacters`
  - Updated property description
  - Added examples
- **`contactPoint`**:
  - Moved email string format to a new definition called `emailAddress`
  - Updated property description
- **`keywords`**:
  - `keywords` can now be a comma separated string using a new definition called `commaSeperatedValues` or an array of unique strings of minimum length = 1
  - Updated property description

**Optional Properties**
- **`identifiers`**:
  - Renamed `identifier` --> `alternate-identifiers` to account for this property to be a list of strings and align with the DATA CITE metadata standard
  - `alternate-identifiers` can be a comma separated string using a new definition called `commaSeperatedValues` or an array of unique strings of minimum length = 1
  - `alternate-identifiers` is not a required property
- **`doiName`**:
  -  Renamed `doi` --> `doiName` to align with the standard
  - `doi` can now be a string pattern defined in `doi`
  - Updated property description
  - Added examples


## Breaking Changes:
- **`identifier`**:
  - `identifier` is now a required property
  -  Renaming `doi` to doiName to align with the standard
> Response:
> As this field is not well-populated this will have minimal impact. However and conversely, if it is not well-populated does it have to be a required property?

- **`keywords`**:
  - `keywords` can now use an array of unique strings of minimum length = 1 is which may break some services that expect `commaSeperatedValues`.
> Response:
> We have tried to minimise the impact by keeping the `commaSeperatedValues` string, which will be deprecated in the next version. The reason we have kept an optional `commaSeperatedValues` formatted string is because the metadata catalogue does not support lists of strings. Do we want to remove this and enforce the use of an array of strings which is better for the longer term?

## Unresolved Questions:
- **`publisher`**:
  - `publisher` still uses only a `eightyCharacters` string
  - It may be worth upgrading to the `Organisation` definition in the Dataset v2 spec. See: PR https://github.com/HDRUK/schemata/pull/3