### PR TITLE
RFC D02: Dataset v2 - Organisation

### DIFF
--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -90,7 +90,6 @@ properties:
       UK Gateway organisation but coordinate activities across a number of data publishers
       i.e. Cambridge Blood and Stem Cell Biobank.
     allOf:
-    - "$ref": "#/definitions/ogranisation"
     - "$ref": "#/definitions/publisher"
   
   contactPoint:
@@ -645,99 +644,101 @@ definitions:
         type: string
         format: email
   
-  publisherOrganisation:
+  publisher:
   type: object
   required:
   - membership
   - accessRights
   - dataUseLimitation
   - dataUseRestriction
-  properties:
-    membership:
-      title: Organisation Membership
-      description: Please indicate if the organisation is an Alliance Member or a Hub.
-      type: string
-      enum:
-      - HUB
-      - ALLIANCE
-      - OTHER
-    accessRights:
-      title: Organisation Default Access Rights
-      description: The URL of a webpage where the data access request process and/or
-        guidance is provided. If there is more than one access process i.e. industry
-        vs academic please provide both. If such a resource or the underlying process
-        doesn’t exist, please provide “In Progress”, until both the process and the
-        documentation are ready.
-      anyOf:
-      - type: string
-        pattern: "^In Progress$"
-      - type: string
-        format: uri
-      - type: array
-        items:
-          type: string
+  allOf:
+  - "$ref": "#/definitions/organisation"
+  - properties:
+      membership:
+        title: Organisation Membership
+        description: Please indicate if the organisation is an Alliance Member or a Hub.
+        type: string
+        enum:
+        - HUB
+        - ALLIANCE
+        - OTHER
+      accessRights:
+        title: Organisation Default Access Rights
+        description: The URL of a webpage where the data access request process and/or
+          guidance is provided. If there is more than one access process i.e. industry
+          vs academic please provide both. If such a resource or the underlying process
+          doesn’t exist, please provide “In Progress”, until both the process and the
+          documentation are ready.
+        anyOf:
+        - type: string
+          pattern: "^In Progress$"
+        - type: string
           format: uri
-      deliveryLeadTime:
-        title: Delivery Lead Time
-        description: "Please provide an indication of the typical processing times based 
-          on the types of requests typically received. Note: This value will be used as 
-          default access request duration for all datasets submitted by the organisation. 
-          However, there will be the opportunity to overwrite his value for each dataset."
-        type: string
-        enum:
-        - '>1 WEEK'
-        - '1-2 WEEKS'
-        - '2-4 WEEKS'
-        - '1-2 MONTHS'
-        - '2-6 MONTHS'
-        - '>6 MONTHS'
-        - 'OTHER'
-      accessService:
-        title: Organisation Access Service
-        description: "Please provide a brief description of the data access environment 
-          that is currently available to researchers. If no environment is currently 
-          available, please indicate the current plans and timelines when the data will be 
-          made available through an access environment or process. Note: This value will be 
-          used as default access environment for all datasets submitted by the organisation. 
-          However, there will be the opportunity to overwrite his value for each dataset"
-        "$ref": "#/definitions/longDescription"
-      dataUseLimitation:
-        title: Data Use Limitation
-        description: "Please provide an indication of consent permissions for datasets and/or 
-          materials, and relates to the purposes for which datasets and/or material might be 
-          removed, stored or used. Notes: where there are existing data-sharing arrangements 
-          such as the HDR UK HUB data sharing agreement or the NIHR HIC data sharing agreement 
-          this should be indicated within access rights. This value will be used as terms for 
-          all datasets submitted by the organisation. However, there will be the opportunity 
-          to overwrite this value for each dataset."
-        type: string
-        enum:
-        - 'GENERAL RESEARCH USE'
-        - 'GENETIC STUDIES ONLY'
-        - 'NO GENERAL METHODS RESEARCH'
-        - 'NO RESTRICTION'
-        - 'RESEARCH SPECIFIC RESTRICTIONS'
-        - 'RESEARCH USE ONLY'
-        - 'NO LINKAGE'
-      dataUseRestriction:
-        title: Data Use restrictions
-        desription: "Please indicate if there are any additional conditions set for use if any. 
-          Please ensure that these restrictions are documented in access rights information. 
-          Note: this value will be used as terms for all datasets submitted by the organisation. 
-          However, there will be an opportunity to overwrite this value for each dataset."
-        type: string
-        enum:
-        - 'COLLABORATION REQUIRED'
-        - 'ETHICS APPROVAL REQUIRED'
-        - 'GEOGRAPHICAL RESTRICTIONS'
-        - 'INSTITUTION SPECIFIC RESTRICTIONS'
-        - 'NOT FOR PROFIT USE'
-        - 'PROJECT SPECIFIC RESTRICTIONS'
-        - 'PUBLICATION MORATORIUM'
-        - 'PUBLICATION REQUIRED'
-        - 'RETURN TO DATABASE OR RESOURCE'
-        - 'TIME LIMIT ON USE'
-        - 'USER SPECIFIC RESTRICTION'
+        - type: array
+          items:
+            type: string
+            format: uri
+        deliveryLeadTime:
+          title: Delivery Lead Time
+          description: "Please provide an indication of the typical processing times based 
+            on the types of requests typically received. Note: This value will be used as 
+            default access request duration for all datasets submitted by the organisation. 
+            However, there will be the opportunity to overwrite his value for each dataset."
+          type: string
+          enum:
+          - '>1 WEEK'
+          - '1-2 WEEKS'
+          - '2-4 WEEKS'
+          - '1-2 MONTHS'
+          - '2-6 MONTHS'
+          - '>6 MONTHS'
+          - 'OTHER'
+        accessService:
+          title: Organisation Access Service
+          description: "Please provide a brief description of the data access environment 
+            that is currently available to researchers. If no environment is currently 
+            available, please indicate the current plans and timelines when the data will be 
+            made available through an access environment or process. Note: This value will be 
+            used as default access environment for all datasets submitted by the organisation. 
+            However, there will be the opportunity to overwrite his value for each dataset"
+          "$ref": "#/definitions/longDescription"
+        dataUseLimitation:
+          title: Data Use Limitation
+          description: "Please provide an indication of consent permissions for datasets and/or 
+            materials, and relates to the purposes for which datasets and/or material might be 
+            removed, stored or used. Notes: where there are existing data-sharing arrangements 
+            such as the HDR UK HUB data sharing agreement or the NIHR HIC data sharing agreement 
+            this should be indicated within access rights. This value will be used as terms for 
+            all datasets submitted by the organisation. However, there will be the opportunity 
+            to overwrite this value for each dataset."
+          type: string
+          enum:
+          - 'GENERAL RESEARCH USE'
+          - 'GENETIC STUDIES ONLY'
+          - 'NO GENERAL METHODS RESEARCH'
+          - 'NO RESTRICTION'
+          - 'RESEARCH SPECIFIC RESTRICTIONS'
+          - 'RESEARCH USE ONLY'
+          - 'NO LINKAGE'
+        dataUseRestriction:
+          title: Data Use restrictions
+          desription: "Please indicate if there are any additional conditions set for use if any. 
+            Please ensure that these restrictions are documented in access rights information. 
+            Note: this value will be used as terms for all datasets submitted by the organisation. 
+            However, there will be an opportunity to overwrite this value for each dataset."
+          type: string
+          enum:
+          - 'COLLABORATION REQUIRED'
+          - 'ETHICS APPROVAL REQUIRED'
+          - 'GEOGRAPHICAL RESTRICTIONS'
+          - 'INSTITUTION SPECIFIC RESTRICTIONS'
+          - 'NOT FOR PROFIT USE'
+          - 'PROJECT SPECIFIC RESTRICTIONS'
+          - 'PUBLICATION MORATORIUM'
+          - 'PUBLICATION REQUIRED'
+          - 'RETURN TO DATABASE OR RESOURCE'
+          - 'TIME LIMIT ON USE'
+          - 'USER SPECIFIC RESTRICTION'
   
   controlledVocabulary:
     type: string

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -89,9 +89,7 @@ properties:
       However, in some cases this will be different i.e. Tissue Directory are an HDR
       UK Gateway organisation but coordinate activities across a number of data publishers
       i.e. Cambridge Blood and Stem Cell Biobank.
-    type: string
-    minLength: 2
-    maxLength: 80
+    "$ref": "#/definitions/controlledVocabulary"
   
   contactPoint:
     "$id": "#/properties/contactPoint"

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -642,6 +642,85 @@ definitions:
         type: string
         format: email
   
+  publisher:
+  type: object
+  required:
+  - membership
+  - accessRights
+  - dataUseLimitation
+  - dataUseRestriction
+  allOf:
+  - "$ref": "#/definitions/organisation"
+  - properties:
+      membership:
+        title: Organisation Membership
+        description: Please indicate if the organisation is an Alliance Member or a Hub.
+        type: string
+        enum:
+        - HUB
+        - ALLIANCE
+        - OTHER
+      accessRights:
+        title: Organisation Default Access Rights
+        description: The URL of a webpage where the data access request process and/or
+          guidance is provided. If there is more than one access process i.e. industry
+          vs academic please provide both. If such a resource or the underlying process
+          doesn’t exist, please provide “In Progress”, until both the process and the
+          documentation are ready.
+        anyOf:
+        - type: string
+          pattern: "^In Progress$"
+        - type: string
+          format: uri
+        - type: array
+          items:
+            type: string
+            format: uri
+        deliveryLeadTime:
+          title: Delivery Lead Time
+          description: "Please provide an indication of the typical processing times based on the types of requests typically received. Note: This value will be used as default access request duration for all datasets submitted by the organisation. However, there will be the opportunity to overwrite his value for each dataset."
+          type: string
+          enum:
+          - '>1 WEEK'
+          - '1-2 WEEKS'
+          - '2-4 WEEKS'
+          - '1-2 MONTHS'
+          - '2-6 MONTHS'
+          - '>6 MONTHS'
+          - 'OTHER'
+        accessService:
+          title: Organisation Access Service
+          description: "Please provide a brief description of the data access environment that is currently available to researchers. If no environment is currently available, please indicate the current plans and timelines when the data will be made available through an access environment or process. Note: This value will be used as default access environment for all datasets submitted by the organisation. However, there will be the opportunity to overwrite his value for each dataset"
+          "$ref": "#/definitions/longDescription"
+        dataUseLimitation:
+          title: Data Use Limitation
+          description: "Please provide an indication of consent permissions for datasets and/or materials, and relates to the purposes for which datasets and/or material might be removed, stored or used. Notes: where there are existing data-sharing arrangements such as the HDR UK HUB data sharing agreement or the NIHR HIC data sharing agreement this should be indicated within access rights. This value will be used as terms for all datasets submitted by the organisation. However, there will be the opportunity to overwrite this value for each dataset."
+          type: string
+          enum:
+          - 'GENERAL RESEARCH USE'
+          - 'GENETIC STUDIES ONLY'
+          - 'NO GENERAL METHODS RESEARCH'
+          - 'NO RESTRICTION'
+          - 'RESEARCH SPECIFIC RESTRICTIONS'
+          - 'RESEARCH USE ONLY'
+          - 'NO LINKAGE'
+        dataUseRestriction:
+          title: Data Use restrictions
+          desription: "Please indicate if there are any additional conditions set for use if any. Please ensure that these restrictions are documented in access rights information. Note: this value will be used as terms for all datasets submitted by the organisation. However, there will be an opportunity to overwrite this value for each dataset."
+          type: string
+          enum:
+          - 'COLLABORATION REQUIRED'
+          - 'ETHICS APPROVAL REQUIRED'
+          - 'GEOGRAPHICAL RESTRICTIONS'
+          - 'INSTITUTION SPECIFIC RESTRICTIONS'
+          - 'NOT FOR PROFIT USE'
+          - 'PROJECT SPECIFIC RESTRICTIONS'
+          - 'PUBLICATION MORATORIUM'
+          - 'PUBLICATION REQUIRED'
+          - 'RETURN TO DATABASE OR RESOURCE'
+          - 'TIME LIMIT ON USE'
+          - 'USER SPECIFIC RESTRICTION'
+  
   controlledVocabulary:
     type: string
     enum:

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -619,7 +619,9 @@ definitions:
     properties:
       id:
         title: Organisation Identifier
-        description: "Please provide a Grid.ac identifier (see https://www.grid.ac/institutes) for your organisation. If your organisation does not have a Grid.ac identifier please use the “suggest and institute” function here: https://www.grid.ac/institutes#"
+        description: "Please provide a Grid.ac identifier (see https://www.grid.ac/institutes) 
+          for your organisation. If your organisation does not have a Grid.ac identifier please 
+          use the “suggest and institute” function here: https://www.grid.ac/institutes#"
         type: string
         format: uri
       name:
@@ -628,7 +630,8 @@ definitions:
         "$ref": "#/definitions/eightyCharacters"
       logo:
         title: Organisation Logo
-        description: Please provide a logo associated with the Gateway Organisation using a valid URL. The following formats will be accepted .jpg, .png or .svg.
+        description: Please provide a logo associated with the Gateway Organisation using a 
+          valid URL. The following formats will be accepted .jpg, .png or .svg.
         type: string
         format: uri
       about:
@@ -676,7 +679,10 @@ definitions:
           format: uri
       deliveryLeadTime:
         title: Delivery Lead Time
-        description: "Please provide an indication of the typical processing times based on the types of requests typically received. Note: This value will be used as default access request duration for all datasets submitted by the organisation. However, there will be the opportunity to overwrite his value for each dataset."
+        description: "Please provide an indication of the typical processing times based 
+          on the types of requests typically received. Note: This value will be used as 
+          default access request duration for all datasets submitted by the organisation. 
+          However, there will be the opportunity to overwrite his value for each dataset."
         type: string
         enum:
         - '>1 WEEK'
@@ -688,11 +694,22 @@ definitions:
         - 'OTHER'
       accessService:
         title: Organisation Access Service
-        description: "Please provide a brief description of the data access environment that is currently available to researchers. If no environment is currently available, please indicate the current plans and timelines when the data will be made available through an access environment or process. Note: This value will be used as default access environment for all datasets submitted by the organisation. However, there will be the opportunity to overwrite his value for each dataset"
+        description: "Please provide a brief description of the data access environment 
+          that is currently available to researchers. If no environment is currently 
+          available, please indicate the current plans and timelines when the data will be 
+          made available through an access environment or process. Note: This value will be 
+          used as default access environment for all datasets submitted by the organisation. 
+          However, there will be the opportunity to overwrite his value for each dataset"
         "$ref": "#/definitions/longDescription"
       dataUseLimitation:
         title: Data Use Limitation
-        description: "Please provide an indication of consent permissions for datasets and/or materials, and relates to the purposes for which datasets and/or material might be removed, stored or used. Notes: where there are existing data-sharing arrangements such as the HDR UK HUB data sharing agreement or the NIHR HIC data sharing agreement this should be indicated within access rights. This value will be used as terms for all datasets submitted by the organisation. However, there will be the opportunity to overwrite this value for each dataset."
+        description: "Please provide an indication of consent permissions for datasets and/or 
+          materials, and relates to the purposes for which datasets and/or material might be 
+          removed, stored or used. Notes: where there are existing data-sharing arrangements 
+          such as the HDR UK HUB data sharing agreement or the NIHR HIC data sharing agreement 
+          this should be indicated within access rights. This value will be used as terms for 
+          all datasets submitted by the organisation. However, there will be the opportunity 
+          to overwrite this value for each dataset."
         type: string
         enum:
         - 'GENERAL RESEARCH USE'
@@ -704,7 +721,10 @@ definitions:
         - 'NO LINKAGE'
       dataUseRestriction:
         title: Data Use restrictions
-        desription: "Please indicate if there are any additional conditions set for use if any. Please ensure that these restrictions are documented in access rights information. Note: this value will be used as terms for all datasets submitted by the organisation. However, there will be an opportunity to overwrite this value for each dataset."
+        desription: "Please indicate if there are any additional conditions set for use if any. 
+          Please ensure that these restrictions are documented in access rights information. 
+          Note: this value will be used as terms for all datasets submitted by the organisation. 
+          However, there will be an opportunity to overwrite this value for each dataset."
         type: string
         enum:
         - 'COLLABORATION REQUIRED'

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -89,7 +89,7 @@ properties:
       However, in some cases this will be different i.e. Tissue Directory are an HDR
       UK Gateway organisation but coordinate activities across a number of data publishers
       i.e. Cambridge Blood and Stem Cell Biobank.
-    "$ref": "#/definitions/controlledVocabulary"
+    "$ref": "#/definitions/publisher"
   
   contactPoint:
     "$id": "#/properties/contactPoint"

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -589,6 +589,16 @@ properties:
       pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
 
 definitions:
+  eightyCharacters:
+    type: string
+    minLength: 2
+    maxLength: 80
+  
+  longDescription:
+    type: string
+    minLength: 5
+    maxLength: 5000
+  
   commaSeparatedValues:
     type: string
     pattern: "([^,]+)"
@@ -596,6 +606,41 @@ definitions:
   numericRange:
     type: string
     pattern: "\\d{1,3}-\\d{1,3}"
+  
+  organisation:
+    required:
+    - name
+    - logo
+    - about
+    - contactPoint
+    type: object
+    title: Organisation Metadata
+    description: Describes an organisation for purposes of discovery and identification.
+    properties:
+      id:
+        title: Organisation Identifier
+        description: "Please provide a Grid.ac identifier (see https://www.grid.ac/institutes) for your organisation. If your organisation does not have a Grid.ac identifier please use the “suggest and institute” function here: https://www.grid.ac/institutes#"
+        type: string
+        format: uri
+      name:
+        title: Organisation Name
+        description: Name of the organisation
+        "$ref": "#/definitions/eightyCharacters"
+      logo:
+        title: Organisation Logo
+        description: Please provide a logo associated with the Gateway Organisation using a valid URL. The following formats will be accepted .jpg, .png or .svg.
+        type: string
+        format: uri
+      about:
+        title: Organisation Description
+        description: Please provide a URL that describes the organisation.
+        type: string
+        format: uri
+      contactPoint:
+        title: Organisation Contact Point
+        description: An explanation about the purpose of this instance.
+        type: string
+        format: email
   
   controlledVocabulary:
     type: string

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -89,7 +89,9 @@ properties:
       However, in some cases this will be different i.e. Tissue Directory are an HDR
       UK Gateway organisation but coordinate activities across a number of data publishers
       i.e. Cambridge Blood and Stem Cell Biobank.
-    "$ref": "#/definitions/publisher"
+    allOf:
+    - "$ref": "#/definitions/ogranisation"
+    - "$ref": "#/definitions/publisher"
   
   contactPoint:
     "$id": "#/properties/contactPoint"
@@ -640,84 +642,82 @@ definitions:
         type: string
         format: email
   
-  publisher:
+  publisherOrganisation:
   type: object
   required:
   - membership
   - accessRights
   - dataUseLimitation
   - dataUseRestriction
-  allOf:
-  - "$ref": "#/definitions/organisation"
-  - properties:
-      membership:
-        title: Organisation Membership
-        description: Please indicate if the organisation is an Alliance Member or a Hub.
+  properties:
+    membership:
+      title: Organisation Membership
+      description: Please indicate if the organisation is an Alliance Member or a Hub.
+      type: string
+      enum:
+      - HUB
+      - ALLIANCE
+      - OTHER
+    accessRights:
+      title: Organisation Default Access Rights
+      description: The URL of a webpage where the data access request process and/or
+        guidance is provided. If there is more than one access process i.e. industry
+        vs academic please provide both. If such a resource or the underlying process
+        doesn’t exist, please provide “In Progress”, until both the process and the
+        documentation are ready.
+      anyOf:
+      - type: string
+        pattern: "^In Progress$"
+      - type: string
+        format: uri
+      - type: array
+        items:
+          type: string
+          format: uri
+      deliveryLeadTime:
+        title: Delivery Lead Time
+        description: "Please provide an indication of the typical processing times based on the types of requests typically received. Note: This value will be used as default access request duration for all datasets submitted by the organisation. However, there will be the opportunity to overwrite his value for each dataset."
         type: string
         enum:
-        - HUB
-        - ALLIANCE
-        - OTHER
-      accessRights:
-        title: Organisation Default Access Rights
-        description: The URL of a webpage where the data access request process and/or
-          guidance is provided. If there is more than one access process i.e. industry
-          vs academic please provide both. If such a resource or the underlying process
-          doesn’t exist, please provide “In Progress”, until both the process and the
-          documentation are ready.
-        anyOf:
-        - type: string
-          pattern: "^In Progress$"
-        - type: string
-          format: uri
-        - type: array
-          items:
-            type: string
-            format: uri
-        deliveryLeadTime:
-          title: Delivery Lead Time
-          description: "Please provide an indication of the typical processing times based on the types of requests typically received. Note: This value will be used as default access request duration for all datasets submitted by the organisation. However, there will be the opportunity to overwrite his value for each dataset."
-          type: string
-          enum:
-          - '>1 WEEK'
-          - '1-2 WEEKS'
-          - '2-4 WEEKS'
-          - '1-2 MONTHS'
-          - '2-6 MONTHS'
-          - '>6 MONTHS'
-          - 'OTHER'
-        accessService:
-          title: Organisation Access Service
-          description: "Please provide a brief description of the data access environment that is currently available to researchers. If no environment is currently available, please indicate the current plans and timelines when the data will be made available through an access environment or process. Note: This value will be used as default access environment for all datasets submitted by the organisation. However, there will be the opportunity to overwrite his value for each dataset"
-          "$ref": "#/definitions/longDescription"
-        dataUseLimitation:
-          title: Data Use Limitation
-          description: "Please provide an indication of consent permissions for datasets and/or materials, and relates to the purposes for which datasets and/or material might be removed, stored or used. Notes: where there are existing data-sharing arrangements such as the HDR UK HUB data sharing agreement or the NIHR HIC data sharing agreement this should be indicated within access rights. This value will be used as terms for all datasets submitted by the organisation. However, there will be the opportunity to overwrite this value for each dataset."
-          type: string
-          enum:
-          - 'GENERAL RESEARCH USE'
-          - 'GENETIC STUDIES ONLY'
-          - 'NO GENERAL METHODS RESEARCH'
-          - 'NO RESTRICTION'
-          - 'RESEARCH SPECIFIC RESTRICTIONS'
-          - 'RESEARCH USE ONLY'
-          - 'NO LINKAGE'
-        dataUseRestriction:
-          title: Data Use restrictions
-          desription: "Please indicate if there are any additional conditions set for use if any. Please ensure that these restrictions are documented in access rights information. Note: this value will be used as terms for all datasets submitted by the organisation. However, there will be an opportunity to overwrite this value for each dataset."
-          type: string
-          enum:
-          - 'COLLABORATION REQUIRED'
-          - 'ETHICS APPROVAL REQUIRED'
-          - 'GEOGRAPHICAL RESTRICTIONS'
-          - 'INSTITUTION SPECIFIC RESTRICTIONS'
-          - 'NOT FOR PROFIT USE'
-          - 'PROJECT SPECIFIC RESTRICTIONS'
-          - 'PUBLICATION MORATORIUM'
-          - 'PUBLICATION REQUIRED'
-          - 'RETURN TO DATABASE OR RESOURCE'
-          - 'TIME LIMIT ON USE'
-          - 'USER SPECIFIC RESTRICTION'
+        - '>1 WEEK'
+        - '1-2 WEEKS'
+        - '2-4 WEEKS'
+        - '1-2 MONTHS'
+        - '2-6 MONTHS'
+        - '>6 MONTHS'
+        - 'OTHER'
+      accessService:
+        title: Organisation Access Service
+        description: "Please provide a brief description of the data access environment that is currently available to researchers. If no environment is currently available, please indicate the current plans and timelines when the data will be made available through an access environment or process. Note: This value will be used as default access environment for all datasets submitted by the organisation. However, there will be the opportunity to overwrite his value for each dataset"
+        "$ref": "#/definitions/longDescription"
+      dataUseLimitation:
+        title: Data Use Limitation
+        description: "Please provide an indication of consent permissions for datasets and/or materials, and relates to the purposes for which datasets and/or material might be removed, stored or used. Notes: where there are existing data-sharing arrangements such as the HDR UK HUB data sharing agreement or the NIHR HIC data sharing agreement this should be indicated within access rights. This value will be used as terms for all datasets submitted by the organisation. However, there will be the opportunity to overwrite this value for each dataset."
+        type: string
+        enum:
+        - 'GENERAL RESEARCH USE'
+        - 'GENETIC STUDIES ONLY'
+        - 'NO GENERAL METHODS RESEARCH'
+        - 'NO RESTRICTION'
+        - 'RESEARCH SPECIFIC RESTRICTIONS'
+        - 'RESEARCH USE ONLY'
+        - 'NO LINKAGE'
+      dataUseRestriction:
+        title: Data Use restrictions
+        desription: "Please indicate if there are any additional conditions set for use if any. Please ensure that these restrictions are documented in access rights information. Note: this value will be used as terms for all datasets submitted by the organisation. However, there will be an opportunity to overwrite this value for each dataset."
+        type: string
+        enum:
+        - 'COLLABORATION REQUIRED'
+        - 'ETHICS APPROVAL REQUIRED'
+        - 'GEOGRAPHICAL RESTRICTIONS'
+        - 'INSTITUTION SPECIFIC RESTRICTIONS'
+        - 'NOT FOR PROFIT USE'
+        - 'PROJECT SPECIFIC RESTRICTIONS'
+        - 'PUBLICATION MORATORIUM'
+        - 'PUBLICATION REQUIRED'
+        - 'RETURN TO DATABASE OR RESOURCE'
+        - 'TIME LIMIT ON USE'
+        - 'USER SPECIFIC RESTRICTION'
   
   controlledVocabulary:
     type: string

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -40,7 +40,7 @@ properties:
     maxLength: 36
     title: Dataset identifier
     description: Dataset identifier
-  
+
   identifier:
     "$id": "#/properties/identifier"
     "$comment": 'FIX SPEC: Conforms to spec, but this MAY be an array of strings.
@@ -52,7 +52,7 @@ properties:
     - type: array
       items:
         type: string
-  
+
   title:
     "$id": "#/properties/title"
     title: Dataset title
@@ -65,7 +65,7 @@ properties:
     type: string
     minLength: 2
     maxLength: 80
-  
+
   abstract:
     "$id": "#/properties/abstract"
     title: Dataset abstract
@@ -78,10 +78,10 @@ properties:
     type: string
     minLength: 5
     maxLength: 255
-  
+
   publisher:
     "$id": "#/properties/publisher"
-    "$comment": Conforms to spec, but this MAY be an an object of organisation
+    "$comment": Conforms to spec, but this MAY be an an object of organisation. https://schema.org/publisher
     title: Dataset publisher
     description: This is the organisation responsible for running or supporting the
       data access request process, as well as publishing and maintaining the metadata.
@@ -89,16 +89,17 @@ properties:
       However, in some cases this will be different i.e. Tissue Directory are an HDR
       UK Gateway organisation but coordinate activities across a number of data publishers
       i.e. Cambridge Blood and Stem Cell Biobank.
-    allOf:
-    - "$ref": "#/definitions/publisher"
-  
+    anyOf:
+    - "$ref": "#/definitions/member"
+    - "$ref": "#/definitions/organisation"
+
   contactPoint:
     "$id": "#/properties/contactPoint"
     title: The contactPoint schema
     description: An explanation about the purpose of this instance.
     type: string
     format: email
-  
+
   accessRights:
     "$id": "#/properties/accessRights"
     "$comment": 'FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality
@@ -118,14 +119,14 @@ properties:
       items:
         type: string
         format: uri
-  
+
   group:
     "$id": "#/properties/group"
     "$comment": Conforms to spec, but this MAY be an array of groups
     title: The group schema
     description: An explanation about the purpose of this instance.
     type: string
-  
+
   description:
     "$id": "#/properties/description"
     title: The description schema
@@ -138,7 +139,7 @@ properties:
       maxLength: 50000
     - type: string
       format: uri
-  
+
   media:
     "$id": "#/properties/media"
     "$comment": 'FIXME: Conforms to spec, but this SHOULD to be an array of URIs as
@@ -156,7 +157,7 @@ properties:
       items:
         type: string
         format: uri
-  
+
   purpose:
     "$id": "#/properties/purpose"
     "$comment": 'FIXME: Mandatory, but cardinality 0:* Possibly deprecate.'
@@ -184,7 +185,7 @@ properties:
         - Audit
         - Administrative
         - Financial
-  
+
   source:
     "$id": "#/properties/source"
     "$comment": 'FIXME: Mandatory, but cardinality 0:* Possibly deprecate.'
@@ -210,8 +211,8 @@ properties:
         - Paper Based
         - Freetext Nlp
         - Machine Generated
-  
-  
+
+
   setting:
     "$id": "#/properties/setting"
     "$comment": 'FIXME: Mandatory, but cardinality 0:*. Possibly deprecate.'
@@ -245,20 +246,20 @@ properties:
         - Home
         - Private
         - Pharmacy
-  
+
   releaseDate:
     "$id": "#/properties/releaseDate"
     title: The releaseDate schema
     description: An explanation about the purpose of this instance.
     type: string
     format: date-time
-  
+
   accessRequestCost:
     "$id": "#/properties/accessRequestCost"
     title: The accessRequestCost schema
     description: An explanation about the purpose of this instance.
     type: string
-  
+
   accessRequestDuration:
     "$id": "#/properties/accessRequestDuration"
     title: The accessRequestDuration schema
@@ -273,7 +274,7 @@ properties:
     - 2-6 Months
     - ">6 Months"
     - Other
-  
+
   accessEnvironment:
     "$id": "#/properties/accessEnvironment"
     title: The accessEnvironment schema
@@ -282,7 +283,7 @@ properties:
     type: string
     minLength: 5
     maxLength: 5000
-  
+
   usageRestrictions:
     "$id": "#/properties/usageRestrictions"
     "$comment": 'FIXME: Missing from Onboarding tool, so not captured'
@@ -296,7 +297,7 @@ properties:
     - type: string
       enum:
       - In Progress
-  
+
   dataController:
     "$id": "#/properties/dataController"
     title: The dataController schema
@@ -306,7 +307,7 @@ properties:
     type: string
     minLength: 5
     maxLength: 5000
-  
+
   dataProcessor:
     "$id": "#/properties/dataProcessor"
     title: The dataProcessor schema
@@ -320,13 +321,13 @@ properties:
     - type: string
       enum:
       - Not Applicable
-  
+
   license:
     "$id": "#/properties/license"
     title: The license schema
     description: An explanation about the purpose of this instance.
     type: string
-  
+
   derivedDatasets:
     "$id": "#/properties/derivedDatasets"
     "$comment": 'FIXME: Conforms to spec, but this SHOULD to be an array of datasets
@@ -345,7 +346,7 @@ properties:
       enum:
       - Not Known
       - Not Available
-  
+
   linkedDataset:
     "$id": "#/properties/linkedDataset"
     "$comment": 'FIXME: If linked $title must start with ''Linked''. FIXME: Conforms
@@ -366,7 +367,7 @@ properties:
       enum:
       - Not Known
       - Not Available
-  
+
   linkageOpportunity:
     "$id": "#/properties/linkageOpportunity"
     title: The linkageOpportunity schema
@@ -383,7 +384,7 @@ properties:
       - Not Known
       - Not Available
     type: string
-  
+
   geographicCoverage:
     "$id": "#/properties/geographicCoverage"
     "$comment": 'FIXME: Update to geoname pattern'
@@ -394,28 +395,28 @@ properties:
     default: ''
     examples:
     - GB
-  
+
   periodicity:
     "$id": "#/properties/periodicity"
     title: The periodicity schema
     description: The frequency at which dataset is published.
     "$ref": "#/definitions/periodicity"
-  
+
   datasetEndDate:
     "$id": "#/properties/datasetEndDate"
     title: The datasetEndDate schema
     description: The end of the time period that the dataset provides coverage for.
     type: string
     format: date
-  
+
   datasetStartDate:
     "$id": "#/properties/datasetStartDate"
     title: The datasetStartDate schema
     description: The start of the time period that the dataset provides coverage for.
     type: string
     format: date
-    
-  
+
+
   jurisdiction:
     "$id": "#/properties/jurisdiction"
     "$comment": 'FIXME: Add ISO 3166-2 Subdivision code pattern'
@@ -425,7 +426,7 @@ properties:
       laws the data subjects’ data is collected, processed and stored.
     type: string
     pattern: "^[A-Z]{2}(-[A-Z]{2,3})?$"
-  
+
   populationType:
     "$id": "#/properties/populationType"
     "$comment": 'FIXME: Check against SNOMED-CT TERMS. Conforms to spec but MAY be
@@ -439,7 +440,7 @@ properties:
     - type: array
       items:
         type: string
-    
+
   disabmiguatingDescription:
     "$id": "#/properties/disabmiguatingDescription"
     "$comment": 'FIXME: MDC is not populated with this value'
@@ -447,8 +448,8 @@ properties:
     description: If SNOMED CT term does not provide sufficient detail, please provide
       a description that disambiguates the population type.
     type: string
-    
-  
+
+
   statisticalPopulation:
     "$id": "#/properties/statisticalPopulation"
     "$comment": 'FIXME: Spec calls this Measured Value'
@@ -459,8 +460,8 @@ properties:
     - type: array
       items:
         type: string
-    
-  
+
+
   ageBand:
     "$id": "#/properties/ageBand"
     "$comment": 'FIXME: Rename MDC response to ageRange according to spec'
@@ -469,7 +470,7 @@ properties:
       dataset. Please provide range in the following format ‘[min age] – [max age]’
       where both the minimum and maximum are whole numbers (integers).
     "$ref": "#/definitions/numericRange"
-  
+
   physicalSampleAvailability:
     "$id": "#/properties/physicalSampleAvailability"
     "$comment": Conforms to spec, but this MAY be an array of strings
@@ -484,7 +485,7 @@ properties:
     default: ''
     examples:
     - Not Available
-  
+
   keywords:
     "$id": "#/properties/keywords"
     "$comment": Conforms to spec, but this MAY be an array of strings
@@ -495,20 +496,20 @@ properties:
     - type: array
       items:
         "$ref": "#/definitions/commaSeparatedValues"
-  
+
   conformsTo:
     title: The conformsTo schema
     description: An explanation about the purpose of this instance.
     "$id": "#/properties/conformsTo"
     "$ref": "#/definitions/conformsTo"
-  
+
   controlledVocabulary:
     "$id": "#/properties/controlledVocabulary"
     "$comment": 'FIXME: Confroms to spec, but MAY be a list of strings'
     title: The controlledVocabulary schema
     description: List any relevant terminologies / ontologies / controlled vocabularies,
       such as ICD 10 Codes, NHS Data Dictionary National Codes or SNOMED CT International,
-      that are being used by the dataset.    
+      that are being used by the dataset.
     anyOf:
     - "$ref": "#/definitions/controlledVocabulary"
     - type: array
@@ -517,7 +518,7 @@ properties:
     default: ''
     examples:
     - See ConformsTo
-  
+
   language:
     "$id": "#/properties/language"
     "$comment": 'FIXME: Conforms to spec, but may be a list of strings given cardinality
@@ -531,7 +532,7 @@ properties:
     - type: array
       items:
         type: string
-  
+
   format:
     "$id": "#/properties/format"
     "$comment": 'FIXME: Conforms to spec, but may be a list of strings given cardinality
@@ -543,7 +544,7 @@ properties:
     - type: array
       items:
         type: string
-  
+
   fileSize:
     "$id": "#/properties/fileSize"
     title: The fileSize schema
@@ -552,7 +553,7 @@ properties:
     default: ''
     examples:
     - 301MB
-  
+
   creator:
     "$id": "#/properties/creator"
     title: The creator schema
@@ -560,7 +561,7 @@ properties:
       citation that credits this dataset. This is typically just the name of the publisher.
       No employee details should be provided.
     type: string
-  
+
   citations:
     "$id": "#/properties/citations"
     "$comment": 'FIXME: Conforms to spec, but may be a list of citation strings'
@@ -573,7 +574,7 @@ properties:
     - type: array
       items:
         type: string
-  
+
   doi:
     "$id": "#/properties/doi"
     title: Digital Object Identifier
@@ -592,78 +593,84 @@ definitions:
     type: string
     minLength: 2
     maxLength: 80
-  
+
   longDescription:
     type: string
     minLength: 5
     maxLength: 5000
-  
+
   commaSeparatedValues:
     type: string
     pattern: "([^,]+)"
-  
+
   numericRange:
     type: string
     pattern: "\\d{1,3}-\\d{1,3}"
-  
+
   organisation:
     required:
     - name
-    - logo
-    - about
     - contactPoint
     type: object
     title: Organisation Metadata
     description: Describes an organisation for purposes of discovery and identification.
     properties:
-      id:
+      identifier:
         title: Organisation Identifier
-        description: "Please provide a Grid.ac identifier (see https://www.grid.ac/institutes) 
-          for your organisation. If your organisation does not have a Grid.ac identifier please 
+        description: "Please provide a Grid.ac identifier (see https://www.grid.ac/institutes)
+          for your organisation. If your organisation does not have a Grid.ac identifier please
           use the “suggest and institute” function here: https://www.grid.ac/institutes#"
         type: string
         format: uri
+        "$comment": https://schema.org/identifier
       name:
         title: Organisation Name
         description: Name of the organisation
         "$ref": "#/definitions/eightyCharacters"
+        "$comment": https://schema.org/contactPoint
       logo:
         title: Organisation Logo
-        description: Please provide a logo associated with the Gateway Organisation using a 
+        description: Please provide a logo associated with the Gateway Organisation using a
           valid URL. The following formats will be accepted .jpg, .png or .svg.
         type: string
         format: uri
-      about:
+        "$comment": https://schema.org/logo
+      description:
         title: Organisation Description
         description: Please provide a URL that describes the organisation.
         type: string
         format: uri
+        "$comment": https://schema.org/description
       contactPoint:
         title: Organisation Contact Point
         description: An explanation about the purpose of this instance.
         type: string
         format: email
-  
-  publisher:
+        "$comment": https://schema.org/contactPoint
+
+  member:
   type: object
   required:
   - membership
   - accessRights
   - dataUseLimitation
   - dataUseRestriction
+  - accessService
   allOf:
   - "$ref": "#/definitions/organisation"
   - properties:
-      membership:
+      memberOf:
         title: Organisation Membership
         description: Please indicate if the organisation is an Alliance Member or a Hub.
         type: string
+        "$comment": https://schema.org/memberOf
         enum:
         - HUB
         - ALLIANCE
         - OTHER
       accessRights:
         title: Organisation Default Access Rights
+        "$comment": dct:access_rights
         description: The URL of a webpage where the data access request process and/or
           guidance is provided. If there is more than one access process i.e. industry
           vs academic please provide both. If such a resource or the underlying process
@@ -680,36 +687,39 @@ definitions:
             format: uri
         deliveryLeadTime:
           title: Delivery Lead Time
-          description: "Please provide an indication of the typical processing times based 
-            on the types of requests typically received. Note: This value will be used as 
-            default access request duration for all datasets submitted by the organisation. 
-            However, there will be the opportunity to overwrite his value for each dataset."
+          "$comment": https://schema.org/deliveryLeadTime
+          description: "Please provide an indication of the typical processing times based
+            on the types of requests typically received. Note: This value will be used as
+            default access request duration for all datasets submitted by the organisation.
+            However, there will be the opportunity to overwrite this value for each dataset."
           type: string
           enum:
-          - '>1 WEEK'
+          - 'LESS 1 WEEK'
           - '1-2 WEEKS'
           - '2-4 WEEKS'
           - '1-2 MONTHS'
           - '2-6 MONTHS'
-          - '>6 MONTHS'
+          - 'MORE 6 MONTHS'
           - 'OTHER'
         accessService:
           title: Organisation Access Service
-          description: "Please provide a brief description of the data access environment 
-            that is currently available to researchers. If no environment is currently 
-            available, please indicate the current plans and timelines when the data will be 
-            made available through an access environment or process. Note: This value will be 
-            used as default access environment for all datasets submitted by the organisation. 
+          "$comment": dcat:accessService
+          description: "Please provide a brief description of the data access environment
+            that is currently available to researchers. If no environment is currently
+            available, please indicate the current plans and timelines when the data will be
+            made available through an access environment or process. Note: This value will be
+            used as default access environment for all datasets submitted by the organisation.
             However, there will be the opportunity to overwrite his value for each dataset"
           "$ref": "#/definitions/longDescription"
         dataUseLimitation:
           title: Data Use Limitation
-          description: "Please provide an indication of consent permissions for datasets and/or 
-            materials, and relates to the purposes for which datasets and/or material might be 
-            removed, stored or used. Notes: where there are existing data-sharing arrangements 
-            such as the HDR UK HUB data sharing agreement or the NIHR HIC data sharing agreement 
-            this should be indicated within access rights. This value will be used as terms for 
-            all datasets submitted by the organisation. However, there will be the opportunity 
+          "$comment": https://www.ebi.ac.uk/ols/ontologies/duo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDUO_0000001
+          description: "Please provide an indication of consent permissions for datasets and/or
+            materials, and relates to the purposes for which datasets and/or material might be
+            removed, stored or used. Notes: where there are existing data-sharing arrangements
+            such as the HDR UK HUB data sharing agreement or the NIHR HIC data sharing agreement
+            this should be indicated within access rights. This value will be used as terms for
+            all datasets submitted by the organisation. However, there will be the opportunity
             to overwrite this value for each dataset."
           type: string
           enum:
@@ -722,9 +732,10 @@ definitions:
           - 'NO LINKAGE'
         dataUseRestriction:
           title: Data Use restrictions
-          desription: "Please indicate if there are any additional conditions set for use if any. 
-            Please ensure that these restrictions are documented in access rights information. 
-            Note: this value will be used as terms for all datasets submitted by the organisation. 
+          "$comment": 	https://www.ebi.ac.uk/ols/ontologies/duo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDUO_0000001
+          desription: "Please indicate if there are any additional conditions set for use if any.
+            Please ensure that these restrictions are documented in access rights information.
+            Note: this value will be used as terms for all datasets submitted by the organisation.
             However, there will be an opportunity to overwrite this value for each dataset."
           type: string
           enum:
@@ -739,7 +750,7 @@ definitions:
           - 'RETURN TO DATABASE OR RESOURCE'
           - 'TIME LIMIT ON USE'
           - 'USER SPECIFIC RESTRICTION'
-  
+
   controlledVocabulary:
     type: string
     enum:
@@ -778,7 +789,7 @@ definitions:
     - 'RXNORM EXTENSION'
     - 'SPL'
     - 'OTHER'
-  
+
   conformsTo:
     type: string
     enum:
@@ -797,7 +808,7 @@ definitions:
     - 'CDISC'
     - 'LOCAL'
     - 'OTHER'
-  
+
   physicalSampleAvailability:
     type: string
     enum:
@@ -822,7 +833,7 @@ definitions:
     - 'URINE'
     - 'WHOLE BLOOD'
     - 'AVAILABILITY TO BE CONFIRMED'
-  
+
   periodicity:
     type: string
     enum:


### PR DESCRIPTION
# RFC D02: Dataset v2 - Organisation
## Summary & Motivation:
This RFC introduces a new `organisation` and `publisher` definitions that will be used to replace the publisher property of the Dataset metadata specification. These new definitions will allow us to capture more information about the publisher and will also allow the publisher to provide default values - `contactPoint`, `accessRights`, `datauseLimitations` and `dataUseRestrictions` for all of their datasets.


### Authors:
- A. Milward (MetadataWorks)
- D. Milward (MetadataWorks)
- S. Varma (HDR UK)

## Detailed List Of Changes:
This RFC is limited to the creation of two new definitions `organisation` and `publisher` and it's use to define the `publisher` property of the dataset specification which is listed below:

**New/Modified Definitions**:
- **`eightyCharacters`**:
  - New string format limited to (2,80) characters
- **`longDescription`**:
  - New string format limited to (5,5000) characters
- **`organisation`**:
  - `identifier`: Organisation Identifier using grid.ac. identifiers (Optional)
  - **`name`**: Organisation Name
  - **`logo`**: Organisation Logo URI
  - **`about`**: Organisation description URI
  - **`contactPoint`**: Organisation Contact Point
- **`member`**:
  - Extends `organisation` definition to include additional properties
  - **`memberOf`**: Organisation Membership
  - **`accessRights`**: Organisation Default Access Rights
  - `deliveryLeadTime`: Delivery lead Time
  - **`accessService`**: Data Access Service
  - **`dataUseLimitation`**: Data Use Limitation
  - **`dataUseRestriction`**: Data Use Restriction


**Required Properties**:
- **`publisher`**:
  - Moved string (2,80) character limit to use new anyOf `member` or `organisation` object definition


## Breaking Changes:
- **`publisher`**:
  - Converting a single (2,80) string format to use the new `publisher` object definition

## Unresolved Questions:
- None