### PR TITLE
RFC D00: Dataset v2 - Versions

### DIFF
--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -7,6 +7,8 @@ version: "1.1.7"
 
 required:
 - id
+- version
+- revisions
 - title
 - abstract
 - publisher
@@ -40,6 +42,20 @@ properties:
     maxLength: 36
     title: Dataset identifier
     description: Dataset identifier
+  
+  version:
+    "$id": "#/properties/version"
+    title: Dataset Version
+    description: Dataset metadata version
+    "$ref": "#/definitions/semver"
+    examples:
+    - "1.1.0"
+  
+  revisions:
+    "$id": "#/properties/revisions"
+    title: Dataset Revisions
+    description: Revisions of Dataset metadata
+    "$ref": "#/definitions/revisions"
   
   identifier:
     "$id": "#/properties/identifier"
@@ -596,6 +612,21 @@ definitions:
   numericRange:
     type: string
     pattern: "\\d{1,3}-\\d{1,3}"
+  
+  semver:
+    type: string
+    pattern: "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$"
+  
+  revisions:
+    type: array
+    items:
+      type: object
+      properties:
+        version:
+          "$ref": "#/definitions/semver"
+        url:
+          type: string
+          format: uri
   
   controlledVocabulary:
     type: string

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -614,6 +614,9 @@ definitions:
     pattern: "\\d{1,3}-\\d{1,3}"
   
   semver:
+    title: Semantic Version
+    description: Semantic versioning of the using a dotted numeric format 
+      MAJOR.MINOR.PATCH
     type: string
     pattern: "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$"
   
@@ -621,10 +624,15 @@ definitions:
     type: array
     items:
       type: object
+      required:
+      - version
+      - url
       properties:
         version:
+          description: Semantic Version
           "$ref": "#/definitions/semver"
         url:
+          description: URL endpoint to obtain the version
           type: string
           format: uri
   

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -9,6 +9,8 @@ required:
 - id
 - version
 - revisions
+- issued
+- modified
 - title
 - abstract
 - publisher
@@ -56,6 +58,22 @@ properties:
     title: Dataset Revisions
     description: Revisions of Dataset metadata
     "$ref": "#/definitions/revisions"
+  
+  issued:
+    "$id": "#/properties/issued"
+    title: Creation Date
+    "$comment": 'dcat:issued'
+    description: Dataset Metadata Creation Date
+    type: string
+    format: date-time
+  
+  modified:
+    "$id": "#/properties/modified"
+    title: Modification Date
+    "$comment": 'dcat:modified'
+    description: Dataset Metadata Creation Date
+    type: string
+    format: date-time
   
   identifier:
     "$id": "#/properties/identifier"


### PR DESCRIPTION
# RFC D00: Dataset v2 - Versions
## Summary & Motivation:
This RFC introduces two new properties `version` and `revisions` that will provide version control of the metadata content. It also includes two ancillary properties `issued` and `modified` to provide the date-times when the metadata was created and modified

### Authors:
- S. Varma (HDR UK)

## Detailed List Of Changes:
This RFC is limited to the creation of four new properties `version`, `revisions` `issued` and `modified` with associated definitions `semver` and `revisions` which as detailed below:

**New Definitions**:
- **`semver`**:
  - New string format that represents the semantic versioning string regex pattern - `^([0-9]+)\.([0-9]+)\.([0-9]+)$`
- **`revisions`**:
  - New array of objects with the following properties:
    - **`version`**: Semantic version as defined by `semver` definition
    - **`url`**: String URI formatted endpoint to obtain the version of the metadata

**Required Properties**:
- **`version`**:
  - New required property that holds value based on the `semver` definition
- **`revisions`**:
  - New required property that holds value based on the `revisions` definition
- **`issued`**:
  - New required property that represents the metadata creation date and is defined by a string in date-time format
- **`modified`**:
  - New required property that represents the metadata modification date and is defined by a string in date-time format


## Breaking Changes:
- **`version`**:
  - New required property
- **`revisions`**:
  - New required property
- **`issued`**:
  - New required property
- **`modified`**:
  - New required property

## Unresolved Questions:
- **`issued`** and **`modified`**:
  - Do we need the metadata creation/modified date-times in the specification?
  - Do we need it to be required?