### PR TITLE
RFC D04: Dataset v2 - Coverage Section

### DIFF
--- a/schema/dataset/latest/dataset.schema.json
+++ b/schema/dataset/latest/dataset.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/HDRUK/schemata/master/schema/dataset/dataset.schema.json",
+  "$id": "http://healthdatagateway.org/schema/dataset.json",
   "type": "object",
   "title": "HDR UK Dataset",
   "description": "HDR UK Dataset Schema",
-  "version": "1.1.7",
   "required": [
     "id",
-    "title",
+    "identifiers",
+    "name",
     "abstract",
     "publisher",
     "contactPoint",
@@ -26,139 +26,256 @@
     "language",
     "format",
     "creator",
-    "doi",
     "usageRestrictions"
   ],
   "additionalProperties": true,
   "properties": {
-    "id": {
-      "$id": "#/properties/id",
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-      "minLength": 36,
-      "maxLength": 36,
-      "title": "Dataset identifier",
-      "description": "Dataset identifier"
-    },
-    "identifier": {
-      "$id": "#/properties/identifier",
-      "$comment": "FIX SPEC: Conforms to spec, but this MAY be an array of strings. FIXME: Rename to local identifier",
-      "title": "Local dataset identifier",
-      "description": "Local dataset identifier",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
+    "summary": {
+      "id": {
+        "$id": "#/properties/summary/id",
+        "title": "Dataset identifier",
+        "description": "Dataset identifier (UUIDv4 format)",
+        "allOf": [
+          {
+            "$ref": "#/definitions/uuidv4"
+          }
+        ]
+      },
+      "identifiers": {
+        "$id": "#/properties/summary/identifier",
+        "$comment": "FIX SPEC: Conforms to spec, but this MAY be an array of strings.",
+        "anyOf": [
+          {
             "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
-        }
-      ]
-    },
-    "title": {
-      "$id": "#/properties/title",
-      "title": "Dataset title",
-      "description": "Name of the dataset limited to 80 characters. It should provide a short description of the dataset and be unique across the gateway. If your title is not unique, please add a prefix with your organisation name or identifier to differentiate it from other datasets within the Gateway. Please avoid acronyms wherever possible. Good titles should summarise the content of the dataset and if relevant, the region the dataset covers.",
-      "type": "string",
-      "minLength": 2,
-      "maxLength": 80
-    },
-    "abstract": {
-      "$id": "#/properties/abstract",
-      "title": "Dataset abstract",
-      "description": "Provide a clear and brief descriptive signpost for researchers who are searching for data that may be relevant to their research. The abstract should allow the reader to determine the scope of the data collection and accurately summarise its content. The optimal length is one paragraph (limited to 255 characters) and effective abstracts should avoid long sentences and abbreviations where possible",
-      "type": "string",
-      "minLength": 5,
-      "maxLength": 255
-    },
-    "publisher": {
-      "$id": "#/properties/publisher",
-      "$comment": "Conforms to spec, but this MAY be an an object of organisation",
-      "title": "Dataset publisher",
-      "description": "This is the organisation responsible for running or supporting the data access request process, as well as publishing and maintaining the metadata. In most this will be the same as the HDR UK Organisation (Hub or Alliance Member). However, in some cases this will be different i.e. Tissue Directory are an HDR UK Gateway organisation but coordinate activities across a number of data publishers i.e. Cambridge Blood and Stem Cell Biobank.",
-      "type": "string",
-      "minLength": 2,
-      "maxLength": 80
-    },
-    "contactPoint": {
-      "$id": "#/properties/contactPoint",
-      "title": "The contactPoint schema",
-      "description": "An explanation about the purpose of this instance.",
-      "type": "string",
-      "format": "email"
-    },
-    "accessRights": {
-      "$id": "#/properties/accessRights",
-      "$comment": "FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality is 1:*",
-      "title": "The accessRights schema",
-      "description": "The URL of a webpage where the data access request process and/or guidance is provided. If there is more than one access process i.e. industry vs academic please provide both. If such a resource or the underlying process doesn’t exist, please provide “In Progress”, until both the process and the documentation are ready.",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^In Progress$"
-        },
-        {
-          "type": "string",
-          "format": "uri"
-        },
-        {
-          "type": "array",
-          "items": {
+        ],
+        "title": "Local dataset identifiers",
+        "description": "Local dataset identifier"
+      },
+      "name": {
+        "$id": "#/properties/summary/name",
+        "$comment": "using name from schema.org, title is reserved word in json schema",
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 80,
+        "title": "title",
+        "description": "Name of the dataset limited to 80 characters. It should provide a short description of the dataset and be unique across the gateway. If your title is not unique, please add a prefix with your organisation name or identifier to differentiate it from other datasets within the Gateway. Please avoid acronyms wherever possible. Good titles should summarise the content of the dataset and if relevant, the region the dataset covers."
+      },
+      "abstract": {
+        "$id": "#/properties/summary/abstract",
+        "type": "string",
+        "minLength": 5,
+        "maxLength": 255,
+        "title": "Dataset abstract",
+        "description": "Provide a clear and brief descriptive signpost for researchers who are searching for data that may be relevant to their research. The abstract should allow the reader to determine the scope of the data collection and accurately summarise its content. The optimal length is one paragraph (limited to 255 characters) and effective abstracts should avoid long sentences and abbreviations where possible"
+      },
+      "publisher": {
+        "$id": "#/properties/summary/publisher",
+        "$comment": "Conforms to spec, but this MAY be an an object of organisation",
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 80,
+        "title": "Dataset publisher",
+        "description": "This is the organisation responsible for running or supporting the data access request process, as well as publishing and maintaining the metadata. In most this will be the same as the HDR UK Organisation (Hub or Alliance Member). However, in some cases this will be different i.e. Tissue Directory are an HDR UK Gateway organisation but coordinate activities across a number of data publishers i.e. Cambridge Blood and Stem Cell Biobank."
+      },
+      "contactPoint": {
+        "$id": "#/properties/summary/contactPoint",
+        "type": "string",
+        "format": "email",
+        "title": "The contactPoint schema",
+        "description": "An explanation about the purpose of this instance."
+      },
+      "keywords": {
+        "$id": "#/properties/summary/keywords",
+        "$comment": "Conforms to spec, but this MAY be an array of strings",
+        "anyOf": [
+          {
+            "type": "string",
+            "pattern": "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+            }
+          }
+        ],
+        "type": "string",
+        "pattern": "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*",
+        "title": "The keywords schema",
+        "description": "An explanation about the purpose of this instance."
+      },
+      "doiName": {
+        "$id": "#/properties/summary/doiName",
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "In Progress"
+            ]
+          },
+          {
+            "type": "string",
+            "pattern": "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$",
+            "title": "Digital Object Identifier",
+            "description": "All HDR UK registered datasets should either have a Digital Object Identifier (DOI) or be working towards obtaining one. If a DOI is available, please provide the DOI."
+          }
+        ]
+      },
+      "accessRights": {
+        "$id": "#/properties/accessRights",
+        "$comment": "FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality",
+        "anyOf": [
+          {
+            "type": "string",
+            "pattern": "^In Progress$"
+          },
+          {
             "type": "string",
             "format": "uri"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            }
           }
-        }
-      ]
+        ],
+        "title": "The accessRights schema",
+        "description": "The URL of a webpage where the data access request process and/or guidance is provided. If there is more than one access process i.e. industry vs academic please provide both. If such a resource or the underlying process doesn’t exist, please provide “In Progress”, until both the process and the documentation are ready."
+      }
     },
-    "group": {
-      "$id": "#/properties/group",
-      "$comment": "Conforms to spec, but this MAY be an array of groups",
-      "title": "The group schema",
-      "description": "An explanation about the purpose of this instance.",
-      "type": "string"
-    },
-    "description": {
-      "$id": "#/properties/description",
-      "title": "The description schema",
-      "description": "A free-text account of the record. An html account of the data that provides context and scope of the data (limited to 50,000 characters) and/or a resolvable URL that describes the dataset.",
-      "anyOf": [
-        {
-          "type": "string",
-          "minLength": 5,
-          "maxLength": 50000
-        },
-        {
-          "type": "string",
-          "format": "uri"
-        }
-      ]
-    },
-    "media": {
-      "$id": "#/properties/media",
-      "$comment": "FIXME: Conforms to spec, but this SHOULD to be an array of URIs as cardinality 0:*",
-      "title": "The media schema",
-      "description": "Please provide any media associated with the Gateway Organisation using a valid URI. This is an opportunity to provide additional context that could be useful for researchers wanting to undestand more about the dataset and its relevance to their research question. The following formats will be accepted .jpg, .png or .svg, .pdf, .xslx or .docx.",
-      "anyOf": [
-        {
-          "type": "string",
-          "format": "uri"
-        },
-        {
-          "type": "array",
-          "items": {
+    "documentation": {
+      "description": {
+        "$id": "#/properties/documentation/description",
+        "type": "string",
+        "minLength": 5,
+        "maxLength": 3000,
+        "title": "The description",
+        "description": "A free-text description of the record."
+      },
+      "additionalDocumentation": {
+        "$id": "#/properties/documentation/additionalDocumentation",
+        "type": "string",
+        "pattern": "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$",
+        "title": "Digital Object Identifier",
+        "description": "All HDR UK registered datasets should either have a Digital Object Identifier (DOI) or be working towards obtaining one. If a DOI is available, please provide the DOI."
+      },
+      "additionalMedia": {
+        "$id": "#/properties/documentation/additionalMedia",
+        "$comment": "FIXME: Conforms to spec, but this SHOULD to be an array of URIs as cardinality 0:*",
+        "anyOf": [
+          {
             "type": "string",
             "format": "uri"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            }
           }
-        }
-      ]
+        ],
+        "title": "The media schema",
+        "description": "Please provide any media associated with the Gateway Organisation using a valid URI. This is an opportunity to provide additional context that could be useful for researchers wanting to undestand more about the dataset and its relevance to their research question. The following formats will be accepted .jpg, .png or .svg, .pdf, .xslx or .docx."
+      },
+      "isPartOf": {
+        "$id": "#/properties/documentation/isPartOf",
+        "$comment": "Conforms to spec, but this MAY be an array of groups",
+        "type": "string",
+        "title": "The group schema",
+        "description": "An explanation about the purpose of this instance."
+      }
+    },
+    "coverage": {
+      "spatial": {
+        "$id": "#/properties/coverage/spatial",
+        "$comment": "FIXME: Update to geoname pattern",
+        "type": "string",
+        "format": "uri",
+        "title": "The Coverage schema",
+        "description": "The geographical area covered by the dataset.",
+        "default": "",
+        "examples": [
+          "GB"
+        ]
+      },
+      "typicalAgeRange": {
+        "$id": "#/properties/coverage/TypicalAgeRange",
+        "$comment": "FIXME: Rename MDC response to ageRange according to spec",
+        "type": "string",
+        "pattern": "\\d{1,3}-\\d{1,3}",
+        "title": "TypicalAgeRange",
+        "description": "Please indicate the age range in whole years of participants in the dataset. Please provide range in the following format ‘[min age] – [max age]’ where both the minimum and maximum are whole numbers (integers)."
+      },
+      "physicalSampleAvailability": {
+        "$id": "#/properties/coverage/physicalSampleAvailability",
+        "type": "string",
+        "enum": [
+          "Not Available",
+          "Bone Marrow",
+          "Cancer Cell Lines",
+          "Core Biopsy",
+          "CDNA/MRNA",
+          "DNA",
+          "Faeces",
+          "Immortalized Cel Lines",
+          "MicroRNA",
+          "Peripheral Blood Cells",
+          "Plasma",
+          "PM Tissue",
+          "Primary Cells",
+          "RNA",
+          "Saliva",
+          "Serum",
+          "Swabs",
+          "Tissue",
+          "Urine",
+          "Whole Blood",
+          "Availability To Be Confirmed"
+        ],
+        "title": "The physicalSampleAvailability schema",
+        "description": "Availability of physical samples associated with the dataset. If samples are available, please indicate the types of samples that are available.",
+        "default": "",
+        "examples": [
+          "Not Available"
+        ]
+      },
+      "followUp": {
+        "$id": "#/properties/coverage/physicalSampleAvailability",
+        "type": "string",
+        "enum": [
+          "0 - 6 MONTHS",
+          "6 - 12 MONTHS",
+          "1 - 10 YEARS",
+          "Greater than 10 YEARS",
+          "UNKNOWN"
+        ],
+        "title": "Follow Up",
+        "description": "If known, what is the typical time span that a patient appears in the dataset (follow up period)"
+      },
+      "pathway": {
+        "$id": "#/properties/coverage/pathway",
+        "type": "string",
+        "minLength": 5,
+        "maxLength": 3000,
+        "pattern": "/^.{5,3000}$",
+        "title": "The short description",
+        "description": "A free-text description of the record."
+      }
     },
     "purpose": {
       "$id": "#/properties/purpose",
       "$comment": "FIXME: Mandatory, but cardinality 0:* Possibly deprecate.",
-      "title": "The purpose schema",
-      "description": "Pleases indicate the purpose(s) that the dataset was collected. Multiple purposes may be provided",
       "anyOf": [
         {
           "type": "string",
@@ -187,13 +304,13 @@
             ]
           }
         }
-      ]
+      ],
+      "title": "The purpose schema",
+      "description": "Pleases indicate the purpose(s) that the dataset was collected. Multiple purposes may be provided"
     },
     "source": {
       "$id": "#/properties/source",
       "$comment": "FIXME: Mandatory, but cardinality 0:* Possibly deprecate.",
-      "title": "The source schema",
-      "description": "Pleases indicate the source(s) that the dataset was collected. Multiple source(s) may be provided",
       "anyOf": [
         {
           "type": "string",
@@ -220,13 +337,13 @@
             ]
           }
         }
-      ]
+      ],
+      "title": "The source schema",
+      "description": "Pleases indicate the source(s) that the dataset was collected. Multiple source(s) may be provided"
     },
     "setting": {
       "$id": "#/properties/setting",
       "$comment": "FIXME: Mandatory, but cardinality 0:*. Possibly deprecate.",
-      "title": "The setting schema",
-      "description": "Pleases indicate the setting(s) where data was collected. Multiple settings may be provided.",
       "anyOf": [
         {
           "type": "string",
@@ -261,25 +378,25 @@
             ]
           }
         }
-      ]
+      ],
+      "title": "The setting schema",
+      "description": "Pleases indicate the setting(s) where data was collected. Multiple settings may be provided."
     },
     "releaseDate": {
       "$id": "#/properties/releaseDate",
-      "title": "The releaseDate schema",
-      "description": "An explanation about the purpose of this instance.",
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "title": "The releaseDate schema",
+      "description": "An explanation about the purpose of this instance."
     },
     "accessRequestCost": {
       "$id": "#/properties/accessRequestCost",
+      "type": "string",
       "title": "The accessRequestCost schema",
-      "description": "An explanation about the purpose of this instance.",
-      "type": "string"
+      "description": "An explanation about the purpose of this instance."
     },
     "accessRequestDuration": {
       "$id": "#/properties/accessRequestDuration",
-      "title": "The accessRequestDuration schema",
-      "description": "Please provide an indication of the typical processing times based on the types of requests typically received.",
       "type": "string",
       "enum": [
         "<1 Week",
@@ -289,21 +406,21 @@
         "2-6 Months",
         ">6 Months",
         "Other"
-      ]
+      ],
+      "title": "The accessRequestDuration schema",
+      "description": "Please provide an indication of the typical processing times based on the types of requests typically received."
     },
     "accessEnvironment": {
       "$id": "#/properties/accessEnvironment",
-      "title": "The accessEnvironment schema",
-      "description": "Please provide a brief description of the data access environment that is currently available to researchers.",
       "type": "string",
       "minLength": 5,
-      "maxLength": 5000
+      "maxLength": 5000,
+      "title": "The accessEnvironment schema",
+      "description": "Please provide a brief description of the data access environment that is currently available to researchers."
     },
     "usageRestrictions": {
       "$id": "#/properties/usageRestrictions",
       "$comment": "FIXME: Missing from Onboarding tool, so not captured",
-      "title": "The usageRestrictions schema",
-      "description": "Please provide a description of any usage restrictions of key terms and conditions under which access to the dataset is provided.",
       "anyOf": [
         {
           "type": "string",
@@ -316,20 +433,20 @@
             "In Progress"
           ]
         }
-      ]
+      ],
+      "title": "The usageRestrictions schema",
+      "description": "Please provide a description of any usage restrictions of key terms and conditions under which access to the dataset is provided."
     },
     "dataController": {
       "$id": "#/properties/dataController",
-      "title": "The dataController schema",
-      "description": "Data Controller means a person/entity who (either alone or jointly or in common with other persons/entities) determines the purposes for which and the way any Data Subject data, specifically personal data or are to be processed.",
       "type": "string",
       "minLength": 5,
-      "maxLength": 5000
+      "maxLength": 5000,
+      "title": "The dataController schema",
+      "description": "Data Controller means a person/entity who (either alone or jointly or in common with other persons/entities) determines the purposes for which and the way any Data Subject data, specifically personal data or are to be processed."
     },
     "dataProcessor": {
       "$id": "#/properties/dataProcessor",
-      "title": "The dataProcessor schema",
-      "description": "A Data Processor, in relation to any Data Subject data, specifically personal data, means any person/entity (other than an employee of the data controller) who processes the data on behalf of the data controller.",
       "anyOf": [
         {
           "type": "string",
@@ -342,19 +459,19 @@
             "Not Applicable"
           ]
         }
-      ]
+      ],
+      "title": "The dataProcessor schema",
+      "description": "A Data Processor, in relation to any Data Subject data, specifically personal data, means any person/entity (other than an employee of the data controller) who processes the data on behalf of the data controller."
     },
     "license": {
       "$id": "#/properties/license",
+      "type": "string",
       "title": "The license schema",
-      "description": "An explanation about the purpose of this instance.",
-      "type": "string"
+      "description": "An explanation about the purpose of this instance."
     },
     "derivedDatasets": {
       "$id": "#/properties/derivedDatasets",
       "$comment": "FIXME: Conforms to spec, but this SHOULD to be an array of datasets as cardinality 0:*",
-      "title": "The derivedDatasets schema",
-      "description": "Indicate if derived datasets or predefined extracts are available and the type of derivation available.",
       "anyOf": [
         {
           "type": "string",
@@ -374,13 +491,13 @@
             "Not Available"
           ]
         }
-      ]
+      ],
+      "title": "The derivedDatasets schema",
+      "description": "Indicate if derived datasets or predefined extracts are available and the type of derivation available."
     },
     "linkedDataset": {
       "$id": "#/properties/linkedDataset",
       "$comment": "FIXME: If linked $title must start with 'Linked'. FIXME: Conforms to spec, but this SHOULD to be an array of datasets as cardinality 0:*",
-      "title": "The linkedDataset schema",
-      "description": "If applicable, please provide the DOI of other datasets that have previously been linked to this dataset and their availability. If no DOI is available, please provide the title of the datasets that can be linked, where possible using the same title of a dataset previously onboarded.",
       "anyOf": [
         {
           "type": "string",
@@ -400,12 +517,12 @@
             "Not Available"
           ]
         }
-      ]
+      ],
+      "title": "The linkedDataset schema",
+      "description": "If applicable, please provide the DOI of other datasets that have previously been linked to this dataset and their availability. If no DOI is available, please provide the title of the datasets that can be linked, where possible using the same title of a dataset previously onboarded."
     },
     "linkageOpportunity": {
       "$id": "#/properties/linkageOpportunity",
-      "title": "The linkageOpportunity schema",
-      "description": "If applicable, please indicate if there is the opportunity to link this dataset to additional data sources. If possible, please describe the data elements that could be used to link to external data sources i.e. region or postcode could be used to link to open datasets such as air pollution or deprivation indices. In addition, please describe the restricted data elements that cannot be used to link to other datasets.",
       "anyOf": [
         {
           "type": "string"
@@ -418,53 +535,53 @@
           ]
         }
       ],
-      "type": "string"
-    },
-    "geographicCoverage": {
-      "$id": "#/properties/geographicCoverage",
-      "$comment": "FIXME: Update to geoname pattern",
-      "title": "The geographicCoverage schema",
-      "description": "The geographical area covered by the dataset.",
       "type": "string",
-      "format": "uri",
-      "default": "",
-      "examples": [
-        "GB"
-      ]
+      "title": "The linkageOpportunity schema",
+      "description": "If applicable, please indicate if there is the opportunity to link this dataset to additional data sources. If possible, please describe the data elements that could be used to link to external data sources i.e. region or postcode could be used to link to open datasets such as air pollution or deprivation indices. In addition, please describe the restricted data elements that cannot be used to link to other datasets."
     },
     "periodicity": {
       "$id": "#/properties/periodicity",
+      "type": "string",
+      "enum": [
+        "Static",
+        "Annual",
+        "Biennial",
+        "Quaterly",
+        "Bimonthly",
+        "Monthly",
+        "Biweekly",
+        "Daily",
+        "Irregular",
+        "Continious"
+      ],
       "title": "The periodicity schema",
-      "description": "The frequency at which dataset is published.",
-      "$ref": "#/definitions/periodicity"
+      "description": "The frequency at which dataset is published."
     },
     "datasetEndDate": {
       "$id": "#/properties/datasetEndDate",
-      "title": "The datasetEndDate schema",
-      "description": "The end of the time period that the dataset provides coverage for.",
       "type": "string",
-      "format": "date"
+      "format": "date",
+      "title": "The datasetEndDate schema",
+      "description": "The end of the time period that the dataset provides coverage for."
     },
     "datasetStartDate": {
       "$id": "#/properties/datasetStartDate",
-      "title": "The datasetStartDate schema",
-      "description": "The start of the time period that the dataset provides coverage for.",
       "type": "string",
-      "format": "date"
+      "format": "date",
+      "title": "The datasetStartDate schema",
+      "description": "The start of the time period that the dataset provides coverage for."
     },
     "jurisdiction": {
       "$id": "#/properties/jurisdiction",
       "$comment": "FIXME: Add ISO 3166-2 Subdivision code pattern",
-      "title": "The jurisdiction schema",
-      "description": "Please use country code from ISO 3166-1 country codes and the associated ISO 3166-2 for regions, cities, states etc. for the country/state under whose laws the data subjects’ data is collected, processed and stored.",
       "type": "string",
-      "pattern": "^[A-Z]{2}(-[A-Z]{2,3})?$"
+      "pattern": "^[A-Z]{2}(-[A-Z]{2,3})?$",
+      "title": "The jurisdiction schema",
+      "description": "Please use country code from ISO 3166-1 country codes and the associated ISO 3166-2 for regions, cities, states etc. for the country/state under whose laws the data subjects’ data is collected, processed and stored."
     },
     "populationType": {
       "$id": "#/properties/populationType",
       "$comment": "FIXME: Check against SNOMED-CT TERMS. Conforms to spec but MAY be array of strings",
-      "title": "The populationType schema",
-      "description": "Please provide a valid SNOMED CT concept that describes the measure within the dataset i.e. participants in a study, modality, or images with certain characteristics.",
       "anyOf": [
         {
           "type": "string"
@@ -475,20 +592,21 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "title": "The populationType schema",
+      "description": "Please provide a valid SNOMED CT concept that describes the measure within the dataset i.e. participants in a study, modality, or images with certain characteristics."
     },
     "disabmiguatingDescription": {
       "$id": "#/properties/disabmiguatingDescription",
-      "$comment": "FIXME: MDC is not populated with this value",
+      "$comment": "FIXME: Rename MDC response to ageRange according to spec",
+      "type": "string",
+      "pattern": "\\d{1,3}-\\d{1,3}",
       "title": "The disabmiguatingDescription schema",
-      "description": "If SNOMED CT term does not provide sufficient detail, please provide a description that disambiguates the population type.",
-      "type": "string"
+      "description": "If SNOMED CT term does not provide sufficient detail, please provide a description that disambiguates the population type."
     },
     "statisticalPopulation": {
       "$id": "#/properties/statisticalPopulation",
       "$comment": "FIXME: Spec calls this Measured Value",
-      "title": "The statisticalPopulation schema",
-      "description": "An explanation about the purpose of this instance.",
       "anyOf": [
         {
           "type": "string"
@@ -499,75 +617,122 @@
             "type": "string"
           }
         }
-      ]
-    },
-    "ageBand": {
-      "$id": "#/properties/ageBand",
-      "$comment": "FIXME: Rename MDC response to ageRange according to spec",
-      "title": "The ageBand schema",
-      "description": "Please indicate the age range in whole years of participants in the dataset. Please provide range in the following format ‘[min age] – [max age]’ where both the minimum and maximum are whole numbers (integers).",
-      "$ref": "#/definitions/numericRange"
-    },
-    "physicalSampleAvailability": {
-      "$id": "#/properties/physicalSampleAvailability",
-      "$comment": "Conforms to spec, but this MAY be an array of strings",
-      "title": "The physicalSampleAvailability schema",
-      "description": "Availability of physical samples associated with the dataset. If samples are available, please indicate the types of samples that are available.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/physicalSampleAvailability"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/physicalSampleAvailability"
-          }
-        }
       ],
-      "default": "",
-      "examples": [
-        "Not Available"
-      ]
-    },
-    "keywords": {
-      "$id": "#/properties/keywords",
-      "$comment": "Conforms to spec, but this MAY be an array of strings",
-      "title": "The keywords schema",
-      "description": "An explanation about the purpose of this instance.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/commaSeparatedValues"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/commaSeparatedValues"
-          }
-        }
-      ]
+      "title": "The statisticalPopulation schema",
+      "description": "An explanation about the purpose of this instance."
     },
     "conformsTo": {
-      "title": "The conformsTo schema",
-      "description": "An explanation about the purpose of this instance.",
       "$id": "#/properties/conformsTo",
-      "$ref": "#/definitions/conformsTo"
+      "type": "string",
+      "enum": [
+        "HL7 FHIR",
+        "HL7 V2",
+        "HL7 CDA",
+        "HL7 CCOW",
+        "LOINC",
+        "DICOM",
+        "I2B2",
+        "IHE",
+        "OMOP",
+        "OPENEHR",
+        "SENTINEL",
+        "PCORNET",
+        "LOCAL",
+        "OTHER"
+      ],
+      "title": "The conformsTo schema",
+      "description": "An explanation about the purpose of this instance."
     },
     "controlledVocabulary": {
       "$id": "#/properties/controlledVocabulary",
       "$comment": "FIXME: Confroms to spec, but MAY be a list of strings",
-      "title": "The controlledVocabulary schema",
-      "description": "List any relevant terminologies / ontologies / controlled vocabularies, such as ICD 10 Codes, NHS Data Dictionary National Codes or SNOMED CT International, that are being used by the dataset.",
       "anyOf": [
         {
-          "$ref": "#/definitions/controlledVocabulary"
+          "type": "string",
+          "enum": [
+            "LOCAL",
+            "OPCS4",
+            "READ",
+            "SNOMED CT",
+            "SNOMED RT",
+            "DM+D",
+            "NHS NATIONAL CODES",
+            "ODS",
+            "LOINC",
+            "ICD10",
+            "ICD10CM",
+            "ICD10PCS",
+            "ICD9CM",
+            "ICD9",
+            "ICDO3",
+            "AMT",
+            "APC",
+            "ATC",
+            "CIEL",
+            "HPO",
+            "CPT4",
+            "DPD",
+            "DRG",
+            "HEMONIC",
+            "JMDC",
+            "KCD7",
+            "MULTUM",
+            "NAACCR",
+            "NDC",
+            "NDFRT",
+            "OXMIS",
+            "RXNORM",
+            "RXNORM EXTENSION",
+            "SPL",
+            "OTHER"
+          ]
         },
         {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/controlledVocabulary"
+            "type": "string",
+            "enum": [
+              "LOCAL",
+              "OPCS4",
+              "READ",
+              "SNOMED CT",
+              "SNOMED RT",
+              "DM+D",
+              "NHS NATIONAL CODES",
+              "ODS",
+              "LOINC",
+              "ICD10",
+              "ICD10CM",
+              "ICD10PCS",
+              "ICD9CM",
+              "ICD9",
+              "ICDO3",
+              "AMT",
+              "APC",
+              "ATC",
+              "CIEL",
+              "HPO",
+              "CPT4",
+              "DPD",
+              "DRG",
+              "HEMONIC",
+              "JMDC",
+              "KCD7",
+              "MULTUM",
+              "NAACCR",
+              "NDC",
+              "NDFRT",
+              "OXMIS",
+              "RXNORM",
+              "RXNORM EXTENSION",
+              "SPL",
+              "OTHER"
+            ]
           }
         }
       ],
+      "title": "The controlledVocabulary schema",
+      "description": "List any relevant terminologies / ontologies / controlled vocabularies, such as ICD 10 Codes, NHS Data Dictionary National Codes or SNOMED CT International, that are being used by the dataset.",
       "default": "",
       "examples": [
         "See ConformsTo"
@@ -576,8 +741,6 @@
     "language": {
       "$id": "#/properties/language",
       "$comment": "FIXME: Conforms to spec, but may be a list of strings given cardinality 1:*. Validate against external list of languages. Resources defined by the Library of Congress (ISO 639-1, ISO 639-2) SHOULD be used.",
-      "title": "The language schema",
-      "description": "This should list all the languages in which the dataset metadata and underlying data is made available.",
       "anyOf": [
         {
           "type": "string"
@@ -588,13 +751,13 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "title": "The language schema",
+      "description": "This should list all the languages in which the dataset metadata and underlying data is made available."
     },
     "format": {
       "$id": "#/properties/format",
       "$comment": "FIXME: Conforms to spec, but may be a list of strings given cardinality 1:*. Validate against external list of formats, e.g. https://www.iana.org/assignments/media-types/media-types.xhtml",
-      "title": "The format schema",
-      "description": "If multiple formats are available please specify.",
       "anyOf": [
         {
           "type": "string"
@@ -605,13 +768,15 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "title": "The format schema",
+      "description": "If multiple formats are available please specify."
     },
     "fileSize": {
       "$id": "#/properties/fileSize",
+      "type": "string",
       "title": "The fileSize schema",
       "description": "An explanation about the purpose of this instance.",
-      "type": "string",
       "default": "",
       "examples": [
         "301MB"
@@ -619,15 +784,13 @@
     },
     "creator": {
       "$id": "#/properties/creator",
+      "type": "string",
       "title": "The creator schema",
-      "description": "Please provide the text that you would like included as part of any citation that credits this dataset. This is typically just the name of the publisher. No employee details should be provided.",
-      "type": "string"
+      "description": "Please provide the text that you would like included as part of any citation that credits this dataset. This is typically just the name of the publisher. No employee details should be provided."
     },
     "citations": {
       "$id": "#/properties/citations",
       "$comment": "FIXME: Conforms to spec, but may be a list of citation strings",
-      "title": "The citations schema",
-      "description": "Please provide the keystone paper associated with the dataset. Also include a list of known citations, if available and should be links to existing resources where the dataset has been used or referenced.",
       "anyOf": [
         {
           "type": "string"
@@ -638,27 +801,32 @@
             "type": "string"
           }
         }
-      ]
-    },
-    "doi": {
-      "$id": "#/properties/doi",
-      "title": "Digital Object Identifier",
-      "description": "All HDR UK registered datasets should either have a Digital Object Identifier (DOI) or be working towards obtaining one. If a DOI is available, please provide the DOI.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "In Progress"
-          ]
-        },
-        {
-          "type": "string",
-          "pattern": "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
-        }
-      ]
+      ],
+      "title": "The citations schema",
+      "description": "Please provide the keystone paper associated with the dataset. Also include a list of known citations, if available and should be links to existing resources where the dataset has been used or referenced."
     }
   },
   "definitions": {
+    "uuidv4": {
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "minLength": 36,
+      "maxLength": 36
+    },
+    "eightyCharacters": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 80
+    },
+    "abstractText": {
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 255
+    },
+    "emailAddress": {
+      "type": "string",
+      "format": "email"
+    },
     "commaSeparatedValues": {
       "type": "string",
       "pattern": "([^,]+)"
@@ -666,6 +834,10 @@
     "numericRange": {
       "type": "string",
       "pattern": "\\d{1,3}-\\d{1,3}"
+    },
+    "doi": {
+      "type": "string",
+      "pattern": "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
     },
     "controlledVocabulary": {
       "type": "string",
@@ -757,8 +929,9 @@
       "type": "string",
       "enum": [
         "STATIC",
-        "ANNUAL",
         "BIENNIAL",
+        "ANNUAL",
+        "BIANNUAL",
         "QUARTERLY",
         "BIMONTHLY",
         "MONTHLY",

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -10,6 +10,7 @@ required:
 - title
 - abstract
 - publisher
+- coverage
 - contactPoint
 - accessRights
 - accessRequestCost
@@ -385,17 +386,6 @@ properties:
       - Not Available
     type: string
   
-  geographicCoverage:
-    "$id": "#/properties/geographicCoverage"
-    "$comment": 'FIXME: Update to geoname pattern'
-    title: The geographicCoverage schema
-    description: The geographical area covered by the dataset.
-    type: string
-    format: uri
-    default: ''
-    examples:
-    - GB
-  
   periodicity:
     "$id": "#/properties/periodicity"
     title: The periodicity schema
@@ -460,31 +450,6 @@ properties:
     - type: array
       items:
         type: string
-    
-  
-  ageBand:
-    "$id": "#/properties/ageBand"
-    "$comment": 'FIXME: Rename MDC response to ageRange according to spec'
-    title: The ageBand schema
-    description: Please indicate the age range in whole years of participants in the
-      dataset. Please provide range in the following format ‘[min age] – [max age]’
-      where both the minimum and maximum are whole numbers (integers).
-    "$ref": "#/definitions/numericRange"
-  
-  physicalSampleAvailability:
-    "$id": "#/properties/physicalSampleAvailability"
-    "$comment": Conforms to spec, but this MAY be an array of strings
-    title: The physicalSampleAvailability schema
-    description: Availability of physical samples associated with the dataset. If
-      samples are available, please indicate the types of samples that are available.
-    anyOf:
-    - "$ref": "#/definitions/physicalSampleAvailability"
-    - type: array
-      items:
-        "$ref": "#/definitions/physicalSampleAvailability"
-    default: ''
-    examples:
-    - Not Available
   
   keywords:
     "$id": "#/properties/keywords"
@@ -593,9 +558,78 @@ definitions:
     type: string
     pattern: "([^,]+)"
   
-  numericRange:
+  ageRange:
     type: string
-    pattern: "\\d{1,3}-\\d{1,3}"
+    pattern: "/(150|1[0-4][0-9]|[0-9]|[1-8][0-9]|9[0-9])-(150|1[0-4][0-9]|[0-9]|[1-8][0-9]|9[0-9])/"
+  
+  shortDescription:
+    type: string
+    minLength: 5
+    maxLength: 3000
+
+  followup:
+    type: string
+    enum:
+    - 0 - 6 MONTHS
+    - 6 - 12 MONTHS
+    - 1 - 10 YEARS
+    - "> 10 YEARS"
+    - UNKNOWN
+
+  coverage:
+    type: object
+    required:
+    - physicalSampleAvailability
+    properties:
+      physicalSampleAvailability:
+        title: Physical Sample Availability
+        "$comment": No standard identified
+        examples:
+        - BONE MARROW
+        type: array
+        items:
+          description: Availability of physical samples associated with the dataset.
+            If samples are available, please indicate the types of samples that are
+            available. More than one type may be provided. If sample are not yet available,
+            please provide “AVAILABILITY TO BE CONFIRMED”. If samples are not available,
+            then please provide “NOT AVAILABLE”.
+          "$ref": "#/definitions/physicalSampleAvailability"
+        minItems: 1
+      spatial:
+        title: Geographic Coverage
+        "$comment": dct:spatial
+        description: 'The geographical area covered by the dataset. Notes: It is recommended
+          that links are to entries in a well-maintained gazetteer such as https://www.geonames.org/'
+        type: string
+        format: uri
+        examples:
+        - https://www.geonames.org/11609043/north-yorkshire.html
+      typicalAgeRange:
+        title: Age Range
+        "$comment": https://schema.org/typicalAgeRange
+        description: 'Guidance: Please indicate the age range in whole years of participants
+          in the dataset. Please provide range in the following format ‘[min age]
+          – [max age]’ where both the minimum and maximum are whole numbers (integers).'
+        "$ref": "#/definitions/ageRange"
+        examples:
+        - 0-18
+      followup:
+        title: Followup
+        "$comment": No standard identified
+        description: If known, what is the typical time span that a patient appears
+          in the dataset (follow up period)
+        "$ref": "#/definitions/followup"
+        default: UNKNOWN
+      pathway:
+        title: Pathway
+        "$comment": No standard identified
+        description: Please indicate if the dataset is representative of the patient
+          pathway and any limitations the dataset may have with respect to pathway
+          coverage. This could include if the dataset is from a single speciality
+          or area, a single tier of care, linked across two tiers (e.g. primary and
+          secondary care), or an integrated care record covering the whole patient
+          pathway.
+        "$ref": "#/definitions/shortDescription"
   
   controlledVocabulary:
     type: string

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -21,7 +21,6 @@ required:
 - jurisdiction
 - populationType
 - statisticalPopulation
-- physicalSampleAvailability
 - keywords
 - conformsTo
 - language
@@ -100,6 +99,14 @@ properties:
     description: An explanation about the purpose of this instance.
     type: string
     format: email
+  
+  coverage:
+    title: Coverage
+    description: This information includes attributes for geographical and temporal
+      coverage, cohort details etc. to enable a deeper understanding of the dataset
+      content so that researchers can make decisions about the relevance of the
+      underlying data.
+    "$ref": "#/definitions/coverage"
   
   accessRights:
     "$id": "#/properties/accessRights"

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -1,16 +1,14 @@
-"$schema": "http://json-schema.org/draft-07/schema"
-"$id": "https://raw.githubusercontent.com/HDRUK/schemata/master/schema/dataset/dataset.schema.json"
+"$schema": http://json-schema.org/draft-07/schema
+"$id": http://healthdatagateway.org/schema/dataset.json
 type: object
 title: HDR UK Dataset
 description: HDR UK Dataset Schema
-version: "1.1.7"
-
 required:
 - id
-- title
+- identifiers
+- name
 - abstract
 - publisher
-- coverage
 - contactPoint
 - accessRights
 - accessRequestCost
@@ -21,157 +19,232 @@ required:
 - jurisdiction
 - populationType
 - statisticalPopulation
+- physicalSampleAvailability
 - keywords
 - conformsTo
 - language
 - format
 - creator
-- doi
 - usageRestrictions
-
 additionalProperties: true
-
 properties:
-  id:
-    "$id": "#/properties/id"
-    type: string
-    pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-    minLength: 36
-    maxLength: 36
-    title: Dataset identifier
-    description: Dataset identifier
-  
-  identifier:
-    "$id": "#/properties/identifier"
-    "$comment": 'FIX SPEC: Conforms to spec, but this MAY be an array of strings.
-      FIXME: Rename to local identifier'
-    title: Local dataset identifier
-    description: Local dataset identifier
-    anyOf:
-    - type: string
-    - type: array
-      items:
-        type: string
-  
-  title:
-    "$id": "#/properties/title"
-    title: Dataset title
-    description: Name of the dataset limited to 80 characters. It should provide a
-      short description of the dataset and be unique across the gateway. If your title
-      is not unique, please add a prefix with your organisation name or identifier
-      to differentiate it from other datasets within the Gateway. Please avoid acronyms
-      wherever possible. Good titles should summarise the content of the dataset and
-      if relevant, the region the dataset covers.
-    type: string
-    minLength: 2
-    maxLength: 80
-  
-  abstract:
-    "$id": "#/properties/abstract"
-    title: Dataset abstract
-    description: Provide a clear and brief descriptive signpost for researchers who
-      are searching for data that may be relevant to their research. The abstract
-      should allow the reader to determine the scope of the data collection and accurately
-      summarise its content. The optimal length is one paragraph (limited to 255 characters)
-      and effective abstracts should avoid long sentences and abbreviations where
-      possible
-    type: string
-    minLength: 5
-    maxLength: 255
-  
-  publisher:
-    "$id": "#/properties/publisher"
-    "$comment": Conforms to spec, but this MAY be an an object of organisation
-    title: Dataset publisher
-    description: This is the organisation responsible for running or supporting the
-      data access request process, as well as publishing and maintaining the metadata.
-      In most this will be the same as the HDR UK Organisation (Hub or Alliance Member).
-      However, in some cases this will be different i.e. Tissue Directory are an HDR
-      UK Gateway organisation but coordinate activities across a number of data publishers
-      i.e. Cambridge Blood and Stem Cell Biobank.
-    type: string
-    minLength: 2
-    maxLength: 80
-  
-  contactPoint:
-    "$id": "#/properties/contactPoint"
-    title: The contactPoint schema
-    description: An explanation about the purpose of this instance.
-    type: string
-    format: email
-  
-  coverage:
-    title: Coverage
-    description: This information includes attributes for geographical and temporal
-      coverage, cohort details etc. to enable a deeper understanding of the dataset
-      content so that researchers can make decisions about the relevance of the
-      underlying data.
-    "$ref": "#/definitions/coverage"
-  
-  accessRights:
-    "$id": "#/properties/accessRights"
-    "$comment": 'FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality
-      is 1:*'
-    title: The accessRights schema
-    description: The URL of a webpage where the data access request process and/or
-      guidance is provided. If there is more than one access process i.e. industry
-      vs academic please provide both. If such a resource or the underlying process
-      doesn’t exist, please provide “In Progress”, until both the process and the
-      documentation are ready.
-    anyOf:
-    - type: string
-      pattern: "^In Progress$"
-    - type: string
-      format: uri
-    - type: array
-      items:
-        type: string
-        format: uri
-  
-  group:
-    "$id": "#/properties/group"
-    "$comment": Conforms to spec, but this MAY be an array of groups
-    title: The group schema
-    description: An explanation about the purpose of this instance.
-    type: string
-  
-  description:
-    "$id": "#/properties/description"
-    title: The description schema
-    description: A free-text account of the record. An html account of the data that
-      provides context and scope of the data (limited to 50,000 characters) and/or
-      a resolvable URL that describes the dataset.
-    anyOf:
-    - type: string
+  summary:
+    id:
+      "$id": "#/properties/summary/id"
+      title: Dataset identifier
+      description: Dataset identifier (UUIDv4 format)
+      allOf:
+      - "$ref": "#/definitions/uuidv4"
+    identifiers:
+      "$id": "#/properties/summary/identifier"
+      "$comment": 'FIX SPEC: Conforms to spec, but this MAY be an array of strings.'
+      anyOf:
+      - type: string
+      - type: array
+        items:
+          type: string
+      title: Local dataset identifiers
+      description: Local dataset identifier
+    name:
+      "$id": "#/properties/summary/name"
+      "$comment": "using name from schema.org, title is reserved word in json schema"
+      type: string
+      minLength: 2
+      maxLength: 80
+      title: title
+      description: Name of the dataset limited to 80 characters. It should provide a
+        short description of the dataset and be unique across the gateway. If your title
+        is not unique, please add a prefix with your organisation name or identifier
+        to differentiate it from other datasets within the Gateway. Please avoid acronyms
+        wherever possible. Good titles should summarise the content of the dataset and
+        if relevant, the region the dataset covers.
+    abstract:
+      "$id": "#/properties/summary/abstract"
+      type: string
       minLength: 5
-      maxLength: 50000
-    - type: string
-      format: uri
-  
-  media:
-    "$id": "#/properties/media"
-    "$comment": 'FIXME: Conforms to spec, but this SHOULD to be an array of URIs as
-      cardinality 0:*'
-    title: The media schema
-    description: Please provide any media associated with the Gateway Organisation
-      using a valid URI. This is an opportunity to provide additional context that
-      could be useful for researchers wanting to undestand more about the dataset
-      and its relevance to their research question. The following formats will be
-      accepted .jpg, .png or .svg, .pdf, .xslx or .docx.
-    anyOf:
-    - type: string
-      format: uri
-    - type: array
-      items:
-        type: string
+      maxLength: 255
+      title: Dataset abstract
+      description: Provide a clear and brief descriptive signpost for researchers who
+        are searching for data that may be relevant to their research. The abstract
+        should allow the reader to determine the scope of the data collection and accurately
+        summarise its content. The optimal length is one paragraph (limited to 255 characters)
+        and effective abstracts should avoid long sentences and abbreviations where
+        possible
+    publisher:
+      "$id": "#/properties/summary/publisher"
+      "$comment": Conforms to spec, but this MAY be an an object of organisation
+      type: string
+      minLength: 2
+      maxLength: 80
+      title: Dataset publisher
+      description: This is the organisation responsible for running or supporting the
+        data access request process, as well as publishing and maintaining the metadata.
+        In most this will be the same as the HDR UK Organisation (Hub or Alliance Member).
+        However, in some cases this will be different i.e. Tissue Directory are an HDR
+        UK Gateway organisation but coordinate activities across a number of data publishers
+        i.e. Cambridge Blood and Stem Cell Biobank.
+    contactPoint:
+      "$id": "#/properties/summary/contactPoint"
+      type: string
+      format: email
+      title: The contactPoint schema  
+      description: An explanation about the purpose of this instance.
+    keywords:
+      "$id": "#/properties/summary/keywords"
+      "$comment": Conforms to spec, but this MAY be an array of strings
+      anyOf:
+        - type: string
+          pattern: "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+        - type: array
+          items:
+            type: string
+            pattern: "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+      type: string
+      pattern: "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+      title: The keywords schema
+      description: An explanation about the purpose of this instance.
+    doiName:
+      "$id": "#/properties/summary/doiName"
+      anyOf:
+      - type: string
+        enum:
+        - In Progress
+      - type: string
+        pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
+        title: Digital Object Identifier
+        description: All HDR UK registered datasets should either have a Digital Object
+            Identifier (DOI) or be working towards obtaining one. If a DOI is available,
+            please provide the DOI.         
+    accessRights:
+      "$id": "#/properties/accessRights"
+      "$comment": 'FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality'
+      anyOf:
+      - type: string
+        pattern: "^In Progress$"
+      - type: string
         format: uri
-  
+      - type: array
+        items:
+          type: string
+          format: uri
+      title: The accessRights schema
+      description: The URL of a webpage where the data access request process and/or
+        guidance is provided. If there is more than one access process i.e. industry
+        vs academic please provide both. If such a resource or the underlying process
+        doesn’t exist, please provide “In Progress”, until both the process and the
+        documentation are ready.
+  documentation:
+    description:
+      "$id": "#/properties/documentation/description"
+      type: string
+      minLength: 5
+      maxLength: 3000
+      title: The description
+      description: A free-text description of the record.
+    additionalDocumentation:
+      "$id": "#/properties/documentation/additionalDocumentation"
+      type: string
+      pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
+      title: Digital Object Identifier
+      description: All HDR UK registered datasets should either have a Digital Object
+              Identifier (DOI) or be working towards obtaining one. If a DOI is available,
+              please provide the DOI.         
+    additionalMedia:
+      "$id": "#/properties/documentation/additionalMedia"
+      "$comment": 'FIXME: Conforms to spec, but this SHOULD to be an array of URIs as
+        cardinality 0:*'
+      anyOf:
+      - type: string
+        format: uri
+      - type: array
+        items:
+          type: string
+          format: uri
+      title: The media schema
+      description: Please provide any media associated with the Gateway Organisation
+        using a valid URI. This is an opportunity to provide additional context that
+        could be useful for researchers wanting to undestand more about the dataset
+        and its relevance to their research question. The following formats will be
+        accepted .jpg, .png or .svg, .pdf, .xslx or .docx.
+    isPartOf:
+      "$id": "#/properties/documentation/isPartOf"
+      "$comment": Conforms to spec, but this MAY be an array of groups
+      type: string
+      title: The group schema
+      description: An explanation about the purpose of this instance.  
+  coverage:
+    spatial:
+      "$id": "#/properties/coverage/spatial"
+      "$comment": 'FIXME: Update to geoname pattern'
+      type: string
+      format: uri
+      title: The Coverage schema
+      description: The geographical area covered by the dataset.
+      default: ''
+      examples:
+      - GB  
+    typicalAgeRange:
+      "$id": "#/properties/coverage/TypicalAgeRange"
+      "$comment": 'FIXME: Rename MDC response to ageRange according to spec'
+      type: string
+      pattern: "\\d{1,3}-\\d{1,3}"
+      title: TypicalAgeRange
+      description: Please indicate the age range in whole years of participants in the
+        dataset. Please provide range in the following format ‘[min age] – [max age]’
+        where both the minimum and maximum are whole numbers (integers).
+    physicalSampleAvailability:
+        "$id": "#/properties/coverage/physicalSampleAvailability"
+        type: string
+        enum:
+        - Not Available
+        - Bone Marrow
+        - Cancer Cell Lines
+        - Core Biopsy
+        - CDNA/MRNA
+        - DNA
+        - Faeces
+        - Immortalized Cel Lines
+        - MicroRNA
+        - Peripheral Blood Cells
+        - Plasma
+        - PM Tissue
+        - Primary Cells
+        - RNA
+        - Saliva
+        - Serum
+        - Swabs
+        - Tissue
+        - Urine
+        - Whole Blood
+        - Availability To Be Confirmed
+        title: The physicalSampleAvailability schema
+        description: Availability of physical samples associated with the dataset. If
+          samples are available, please indicate the types of samples that are available.
+        default: ''
+        examples:
+        - Not Available 
+    followUp:
+      "$id": "#/properties/coverage/physicalSampleAvailability"
+      type: string
+      enum:
+        - 0 - 6 MONTHS
+        - 6 - 12 MONTHS
+        - 1 - 10 YEARS	
+        - Greater than 10 YEARS	
+        - UNKNOWN
+      title: Follow Up
+      description: If known, what is the typical time span that a patient appears in the dataset (follow up period)
+    pathway:
+        "$id": "#/properties/coverage/pathway"
+        type: string
+        minLength: 5
+        maxLength: 3000
+        pattern: "/^.{5,3000}$"
+        title: The short description
+        description: A free-text description of the record.
   purpose:
     "$id": "#/properties/purpose"
     "$comment": 'FIXME: Mandatory, but cardinality 0:* Possibly deprecate.'
-    title: The purpose schema
-    description: Pleases indicate the purpose(s) that the dataset was collected. Multiple
-      purposes may be provided
     anyOf:
     - type: string
       enum:
@@ -193,13 +266,12 @@ properties:
         - Audit
         - Administrative
         - Financial
-  
+    title: The purpose schema
+    description: Pleases indicate the purpose(s) that the dataset was collected. Multiple
+      purposes may be provided
   source:
     "$id": "#/properties/source"
     "$comment": 'FIXME: Mandatory, but cardinality 0:* Possibly deprecate.'
-    title: The source schema
-    description: Pleases indicate the source(s) that the dataset was collected. Multiple
-      source(s) may be provided
     anyOf:
     - type: string
       enum:
@@ -219,14 +291,12 @@ properties:
         - Paper Based
         - Freetext Nlp
         - Machine Generated
-  
-  
+    title: The source schema
+    description: Pleases indicate the source(s) that the dataset was collected. Multiple
+      source(s) may be provided
   setting:
     "$id": "#/properties/setting"
     "$comment": 'FIXME: Mandatory, but cardinality 0:*. Possibly deprecate.'
-    title: The setting schema
-    description: Pleases indicate the setting(s) where data was collected. Multiple
-      settings may be provided.
     anyOf:
     - type: string
       enum:
@@ -254,25 +324,22 @@ properties:
         - Home
         - Private
         - Pharmacy
-  
+    title: The setting schema
+    description: Pleases indicate the setting(s) where data was collected. Multiple
+      settings may be provided.
   releaseDate:
     "$id": "#/properties/releaseDate"
-    title: The releaseDate schema
-    description: An explanation about the purpose of this instance.
     type: string
     format: date-time
-  
+    title: The releaseDate schema
+    description: An explanation about the purpose of this instance.
   accessRequestCost:
     "$id": "#/properties/accessRequestCost"
+    type: string
     title: The accessRequestCost schema
     description: An explanation about the purpose of this instance.
-    type: string
-  
   accessRequestDuration:
     "$id": "#/properties/accessRequestDuration"
-    title: The accessRequestDuration schema
-    description: Please provide an indication of the typical processing times based
-      on the types of requests typically received.
     type: string
     enum:
     - "<1 Week"
@@ -282,22 +349,20 @@ properties:
     - 2-6 Months
     - ">6 Months"
     - Other
-  
+    title: The accessRequestDuration schema
+    description: Please provide an indication of the typical processing times based
+      on the types of requests typically received.
   accessEnvironment:
     "$id": "#/properties/accessEnvironment"
-    title: The accessEnvironment schema
-    description: Please provide a brief description of the data access environment
-      that is currently available to researchers.
     type: string
     minLength: 5
     maxLength: 5000
-  
+    title: The accessEnvironment schema
+    description: Please provide a brief description of the data access environment
+      that is currently available to researchers.
   usageRestrictions:
     "$id": "#/properties/usageRestrictions"
     "$comment": 'FIXME: Missing from Onboarding tool, so not captured'
-    title: The usageRestrictions schema
-    description: Please provide a description of any usage restrictions of key terms
-      and conditions under which access to the dataset is provided.
     anyOf:
     - type: string
       minLength: 5
@@ -305,23 +370,20 @@ properties:
     - type: string
       enum:
       - In Progress
-  
+    title: The usageRestrictions schema
+    description: Please provide a description of any usage restrictions of key terms
+      and conditions under which access to the dataset is provided.
   dataController:
     "$id": "#/properties/dataController"
+    type: string
+    minLength: 5
+    maxLength: 5000
     title: The dataController schema
     description: Data Controller means a person/entity who (either alone or jointly
       or in common with other persons/entities) determines the purposes for which
       and the way any Data Subject data, specifically personal data or are to be processed.
-    type: string
-    minLength: 5
-    maxLength: 5000
-  
   dataProcessor:
     "$id": "#/properties/dataProcessor"
-    title: The dataProcessor schema
-    description: A Data Processor, in relation to any Data Subject data, specifically
-      personal data, means any person/entity (other than an employee of the data controller)
-      who processes the data on behalf of the data controller.
     anyOf:
     - type: string
       minLength: 5
@@ -329,20 +391,19 @@ properties:
     - type: string
       enum:
       - Not Applicable
-  
+    title: The dataProcessor schema
+    description: A Data Processor, in relation to any Data Subject data, specifically
+      personal data, means any person/entity (other than an employee of the data controller)
+      who processes the data on behalf of the data controller.
   license:
     "$id": "#/properties/license"
+    type: string
     title: The license schema
     description: An explanation about the purpose of this instance.
-    type: string
-  
   derivedDatasets:
     "$id": "#/properties/derivedDatasets"
     "$comment": 'FIXME: Conforms to spec, but this SHOULD to be an array of datasets
       as cardinality 0:*'
-    title: The derivedDatasets schema
-    description: Indicate if derived datasets or predefined extracts are available
-      and the type of derivation available.
     anyOf:
     - type: string
       format: uri
@@ -354,30 +415,38 @@ properties:
       enum:
       - Not Known
       - Not Available
-  
+    title: The derivedDatasets schema
+    description: Indicate if derived datasets or predefined extracts are available
+      and the type of derivation available.
   linkedDataset:
     "$id": "#/properties/linkedDataset"
     "$comment": 'FIXME: If linked $title must start with ''Linked''. FIXME: Conforms
       to spec, but this SHOULD to be an array of datasets as cardinality 0:*'
+    anyOf:
+    - type: string
+      format: uri
+    - type: array
+      items:
+        type: string
+        format: uri
+    - type: string
+      enum:
+      - Not Known
+      - Not Available
     title: The linkedDataset schema
     description: If applicable, please provide the DOI of other datasets that have
       previously been linked to this dataset and their availability. If no DOI is
       available, please provide the title of the datasets that can be linked, where
       possible using the same title of a dataset previously onboarded.
+  linkageOpportunity:
+    "$id": "#/properties/linkageOpportunity"
     anyOf:
     - type: string
-      format: uri
-    - type: array
-      items:
-        type: string
-        format: uri
     - type: string
       enum:
       - Not Known
       - Not Available
-  
-  linkageOpportunity:
-    "$id": "#/properties/linkageOpportunity"
+    type: string
     title: The linkageOpportunity schema
     description: If applicable, please indicate if there is the opportunity to link
       this dataset to additional data sources. If possible, please describe the data
@@ -385,258 +454,266 @@ properties:
       postcode could be used to link to open datasets such as air pollution or deprivation
       indices. In addition, please describe the restricted data elements that cannot
       be used to link to other datasets.
-    anyOf:
-    - type: string
-    - type: string
-      enum:
-      - Not Known
-      - Not Available
-    type: string
-  
   periodicity:
     "$id": "#/properties/periodicity"
+    type: string
+    enum:
+    - Static
+    - Annual
+    - Biennial
+    - Quaterly
+    - Bimonthly
+    - Monthly
+    - Biweekly
+    - Daily
+    - Irregular
+    - Continious
     title: The periodicity schema
     description: The frequency at which dataset is published.
-    "$ref": "#/definitions/periodicity"
-  
   datasetEndDate:
     "$id": "#/properties/datasetEndDate"
+    type: string
+    format: date
     title: The datasetEndDate schema
     description: The end of the time period that the dataset provides coverage for.
-    type: string
-    format: date
-  
   datasetStartDate:
     "$id": "#/properties/datasetStartDate"
-    title: The datasetStartDate schema
-    description: The start of the time period that the dataset provides coverage for.
     type: string
     format: date
-    
-  
+    title: The datasetStartDate schema
+    description: The start of the time period that the dataset provides coverage for.
   jurisdiction:
     "$id": "#/properties/jurisdiction"
     "$comment": 'FIXME: Add ISO 3166-2 Subdivision code pattern'
+    type: string
+    pattern: "^[A-Z]{2}(-[A-Z]{2,3})?$"
     title: The jurisdiction schema
     description: Please use country code from ISO 3166-1 country codes and the associated
       ISO 3166-2 for regions, cities, states etc. for the country/state under whose
       laws the data subjects’ data is collected, processed and stored.
-    type: string
-    pattern: "^[A-Z]{2}(-[A-Z]{2,3})?$"
-  
   populationType:
     "$id": "#/properties/populationType"
     "$comment": 'FIXME: Check against SNOMED-CT TERMS. Conforms to spec but MAY be
       array of strings'
+    anyOf:
+    - type: string
+    - type: array
+      items:
+        type: string
     title: The populationType schema
     description: Please provide a valid SNOMED CT concept that describes the measure
       within the dataset i.e. participants in a study, modality, or images with certain
       characteristics.
-    anyOf:
-    - type: string
-    - type: array
-      items:
-        type: string
-    
   disabmiguatingDescription:
     "$id": "#/properties/disabmiguatingDescription"
-    "$comment": 'FIXME: MDC is not populated with this value'
+    "$comment": 'FIXME: Rename MDC response to ageRange according to spec'
+    type: string
+    pattern: "\\d{1,3}-\\d{1,3}"
     title: The disabmiguatingDescription schema
     description: If SNOMED CT term does not provide sufficient detail, please provide
       a description that disambiguates the population type.
-    type: string
-    
-  
   statisticalPopulation:
     "$id": "#/properties/statisticalPopulation"
     "$comment": 'FIXME: Spec calls this Measured Value'
-    title: The statisticalPopulation schema
-    description: An explanation about the purpose of this instance.
     anyOf:
     - type: string
     - type: array
       items:
         type: string
-  
-  keywords:
-    "$id": "#/properties/keywords"
-    "$comment": Conforms to spec, but this MAY be an array of strings
-    title: The keywords schema
+    title: The statisticalPopulation schema
     description: An explanation about the purpose of this instance.
-    anyOf:
-    - "$ref": "#/definitions/commaSeparatedValues"
-    - type: array
-      items:
-        "$ref": "#/definitions/commaSeparatedValues"
   
   conformsTo:
+    "$id": "#/properties/conformsTo"
+    type: string
+    enum:
+    - HL7 FHIR
+    - HL7 V2
+    - HL7 CDA
+    - HL7 CCOW
+    - LOINC
+    - DICOM
+    - I2B2
+    - IHE
+    - OMOP
+    - OPENEHR
+    - SENTINEL
+    - PCORNET
+    - LOCAL
+    - OTHER
     title: The conformsTo schema
     description: An explanation about the purpose of this instance.
-    "$id": "#/properties/conformsTo"
-    "$ref": "#/definitions/conformsTo"
-  
   controlledVocabulary:
     "$id": "#/properties/controlledVocabulary"
     "$comment": 'FIXME: Confroms to spec, but MAY be a list of strings'
+    anyOf:
+    - type: string
+      enum:
+      - LOCAL
+      - OPCS4
+      - READ
+      - SNOMED CT
+      - SNOMED RT
+      - DM+D
+      - NHS NATIONAL CODES
+      - ODS
+      - LOINC
+      - ICD10
+      - ICD10CM
+      - ICD10PCS
+      - ICD9CM
+      - ICD9
+      - ICDO3
+      - AMT
+      - APC
+      - ATC
+      - CIEL
+      - HPO
+      - CPT4
+      - DPD
+      - DRG
+      - HEMONIC
+      - JMDC
+      - KCD7
+      - MULTUM
+      - NAACCR
+      - NDC
+      - NDFRT
+      - OXMIS
+      - RXNORM
+      - RXNORM EXTENSION
+      - SPL
+      - OTHER
+    - type: array
+      items:
+        type: string
+        enum:
+        - LOCAL
+        - OPCS4
+        - READ
+        - SNOMED CT
+        - SNOMED RT
+        - DM+D
+        - NHS NATIONAL CODES
+        - ODS
+        - LOINC
+        - ICD10
+        - ICD10CM
+        - ICD10PCS
+        - ICD9CM
+        - ICD9
+        - ICDO3
+        - AMT
+        - APC
+        - ATC
+        - CIEL
+        - HPO
+        - CPT4
+        - DPD
+        - DRG
+        - HEMONIC
+        - JMDC
+        - KCD7
+        - MULTUM
+        - NAACCR
+        - NDC
+        - NDFRT
+        - OXMIS
+        - RXNORM
+        - RXNORM EXTENSION
+        - SPL
+        - OTHER
     title: The controlledVocabulary schema
     description: List any relevant terminologies / ontologies / controlled vocabularies,
       such as ICD 10 Codes, NHS Data Dictionary National Codes or SNOMED CT International,
-      that are being used by the dataset.    
-    anyOf:
-    - "$ref": "#/definitions/controlledVocabulary"
-    - type: array
-      items:
-        "$ref": "#/definitions/controlledVocabulary"
+      that are being used by the dataset.
     default: ''
     examples:
     - See ConformsTo
-  
   language:
     "$id": "#/properties/language"
     "$comment": 'FIXME: Conforms to spec, but may be a list of strings given cardinality
       1:*. Validate against external list of languages. Resources defined by the Library
       of Congress (ISO 639-1, ISO 639-2) SHOULD be used.'
-    title: The language schema
-    description: This should list all the languages in which the dataset metadata
-      and underlying data is made available.
     anyOf:
     - type: string
     - type: array
       items:
         type: string
-  
+    title: The language schema
+    description: This should list all the languages in which the dataset metadata
+      and underlying data is made available.
   format:
     "$id": "#/properties/format"
     "$comment": 'FIXME: Conforms to spec, but may be a list of strings given cardinality
       1:*. Validate against external list of formats, e.g. https://www.iana.org/assignments/media-types/media-types.xhtml'
-    title: The format schema
-    description: If multiple formats are available please specify.
     anyOf:
     - type: string
     - type: array
       items:
         type: string
-  
+    title: The format schema
+    description: If multiple formats are available please specify.
   fileSize:
     "$id": "#/properties/fileSize"
+    type: string
     title: The fileSize schema
     description: An explanation about the purpose of this instance.
-    type: string
     default: ''
     examples:
     - 301MB
-  
   creator:
     "$id": "#/properties/creator"
+    type: string
     title: The creator schema
     description: Please provide the text that you would like included as part of any
       citation that credits this dataset. This is typically just the name of the publisher.
       No employee details should be provided.
-    type: string
-  
   citations:
     "$id": "#/properties/citations"
     "$comment": 'FIXME: Conforms to spec, but may be a list of citation strings'
-    title: The citations schema
-    description: Please provide the keystone paper associated with the dataset. Also
-      include a list of known citations, if available and should be links to existing
-      resources where the dataset has been used or referenced.
     anyOf:
     - type: string
     - type: array
       items:
         type: string
-  
-  doi:
-    "$id": "#/properties/doi"
-    title: Digital Object Identifier
-    description: All HDR UK registered datasets should either have a Digital Object
-      Identifier (DOI) or be working towards obtaining one. If a DOI is available,
-      please provide the DOI.
-    anyOf:
-    - type: string
-      enum:
-      - In Progress
-    - type: string
-      pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
+    title: The citations schema
+    description: Please provide the keystone paper associated with the dataset. Also
+      include a list of known citations, if available and should be links to existing
+      resources where the dataset has been used or referenced.
 
 definitions:
+  uuidv4:
+    type: string
+    pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    minLength: 36
+    maxLength: 36
+  
+  eightyCharacters:
+    type: string
+    minLength: 2
+    maxLength: 80
+  
+  abstractText:
+    type: string
+    minLength: 5
+    maxLength: 255
+  
+  emailAddress:
+    type: string
+    format: email
+  
   commaSeparatedValues:
     type: string
     pattern: "([^,]+)"
   
-  ageRange:
+  numericRange:
     type: string
-    pattern: "/(150|1[0-4][0-9]|[0-9]|[1-8][0-9]|9[0-9])-(150|1[0-4][0-9]|[0-9]|[1-8][0-9]|9[0-9])/"
+    pattern: "\\d{1,3}-\\d{1,3}"
   
-  shortDescription:
+  doi:
     type: string
-    minLength: 5
-    maxLength: 3000
-
-  followup:
-    type: string
-    enum:
-    - 0 - 6 MONTHS
-    - 6 - 12 MONTHS
-    - 1 - 10 YEARS
-    - "> 10 YEARS"
-    - UNKNOWN
-
-  coverage:
-    type: object
-    required:
-    - physicalSampleAvailability
-    properties:
-      physicalSampleAvailability:
-        title: Physical Sample Availability
-        "$comment": No standard identified
-        examples:
-        - BONE MARROW
-        type: array
-        items:
-          description: Availability of physical samples associated with the dataset.
-            If samples are available, please indicate the types of samples that are
-            available. More than one type may be provided. If sample are not yet available,
-            please provide “AVAILABILITY TO BE CONFIRMED”. If samples are not available,
-            then please provide “NOT AVAILABLE”.
-          "$ref": "#/definitions/physicalSampleAvailability"
-        minItems: 1
-      spatial:
-        title: Geographic Coverage
-        "$comment": dct:spatial
-        description: 'The geographical area covered by the dataset. Notes: It is recommended
-          that links are to entries in a well-maintained gazetteer such as https://www.geonames.org/'
-        type: string
-        format: uri
-        examples:
-        - https://www.geonames.org/11609043/north-yorkshire.html
-      typicalAgeRange:
-        title: Age Range
-        "$comment": https://schema.org/typicalAgeRange
-        description: 'Guidance: Please indicate the age range in whole years of participants
-          in the dataset. Please provide range in the following format ‘[min age]
-          – [max age]’ where both the minimum and maximum are whole numbers (integers).'
-        "$ref": "#/definitions/ageRange"
-        examples:
-        - 0-18
-      followup:
-        title: Followup
-        "$comment": No standard identified
-        description: If known, what is the typical time span that a patient appears
-          in the dataset (follow up period)
-        "$ref": "#/definitions/followup"
-        default: UNKNOWN
-      pathway:
-        title: Pathway
-        "$comment": No standard identified
-        description: Please indicate if the dataset is representative of the patient
-          pathway and any limitations the dataset may have with respect to pathway
-          coverage. This could include if the dataset is from a single speciality
-          or area, a single tier of care, linked across two tiers (e.g. primary and
-          secondary care), or an integrated care record covering the whole patient
-          pathway.
-        "$ref": "#/definitions/shortDescription"
+    pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
   
   controlledVocabulary:
     type: string
@@ -725,8 +802,9 @@ definitions:
     type: string
     enum:
     - STATIC
-    - ANNUAL
     - BIENNIAL
+    - ANNUAL
+    - BIANNUAL
     - QUARTERLY
     - BIMONTHLY
     - MONTHLY
@@ -736,3 +814,4 @@ definitions:
     - DAILY
     - IRREGULAR
     - CONTINUOUS
+

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -87,7 +87,7 @@ properties:
       "$id": "#/properties/summary/contactPoint"
       type: string
       format: email
-      title: The contactPoint schema  
+      title: The contactPoint schema
       description: An explanation about the purpose of this instance.
     keywords:
       "$id": "#/properties/summary/keywords"
@@ -114,7 +114,7 @@ properties:
         title: Digital Object Identifier
         description: All HDR UK registered datasets should either have a Digital Object
             Identifier (DOI) or be working towards obtaining one. If a DOI is available,
-            please provide the DOI.         
+            please provide the DOI.
     accessRights:
       "$id": "#/properties/accessRights"
       "$comment": 'FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality'
@@ -148,7 +148,7 @@ properties:
       title: Digital Object Identifier
       description: All HDR UK registered datasets should either have a Digital Object
               Identifier (DOI) or be working towards obtaining one. If a DOI is available,
-              please provide the DOI.         
+              please provide the DOI.
     additionalMedia:
       "$id": "#/properties/documentation/additionalMedia"
       "$comment": 'FIXME: Conforms to spec, but this SHOULD to be an array of URIs as
@@ -171,77 +171,68 @@ properties:
       "$comment": Conforms to spec, but this MAY be an array of groups
       type: string
       title: The group schema
-      description: An explanation about the purpose of this instance.  
+      description: An explanation about the purpose of this instance.
   coverage:
     spatial:
       "$id": "#/properties/coverage/spatial"
-      "$comment": 'FIXME: Update to geoname pattern'
-      type: string
-      format: uri
-      title: The Coverage schema
-      description: The geographical area covered by the dataset.
+      title: Geographic Coverage
+      "$comment": dct:spatial
+      description: The geographical area covered by the dataset. It is recommended that links are to entries in a well-maintained gazetteer such as https://www.geonames.org/ or https://what3words.com/daring.lion.race.
       default: ''
       examples:
-      - GB  
+      - GB
+      anyOf:
+      - "$ref": "#/definitions/url"
+      - type: string
     typicalAgeRange:
       "$id": "#/properties/coverage/TypicalAgeRange"
-      "$comment": 'FIXME: Rename MDC response to ageRange according to spec'
-      type: string
-      pattern: "\\d{1,3}-\\d{1,3}"
-      title: TypicalAgeRange
+      "$comment": https://schema.org/typicalAgeRange
+      title: Age Range
       description: Please indicate the age range in whole years of participants in the
         dataset. Please provide range in the following format ‘[min age] – [max age]’
         where both the minimum and maximum are whole numbers (integers).
+      allOf:
+      - "$ref": "#/definitions/ageRange"
     physicalSampleAvailability:
-        "$id": "#/properties/coverage/physicalSampleAvailability"
-        type: string
-        enum:
-        - Not Available
-        - Bone Marrow
-        - Cancer Cell Lines
-        - Core Biopsy
-        - CDNA/MRNA
-        - DNA
-        - Faeces
-        - Immortalized Cel Lines
-        - MicroRNA
-        - Peripheral Blood Cells
-        - Plasma
-        - PM Tissue
-        - Primary Cells
-        - RNA
-        - Saliva
-        - Serum
-        - Swabs
-        - Tissue
-        - Urine
-        - Whole Blood
-        - Availability To Be Confirmed
-        title: The physicalSampleAvailability schema
-        description: Availability of physical samples associated with the dataset. If
-          samples are available, please indicate the types of samples that are available.
-        default: ''
-        examples:
-        - Not Available 
-    followUp:
       "$id": "#/properties/coverage/physicalSampleAvailability"
-      type: string
-      enum:
-        - 0 - 6 MONTHS
-        - 6 - 12 MONTHS
-        - 1 - 10 YEARS	
-        - Greater than 10 YEARS	
-        - UNKNOWN
-      title: Follow Up
-      description: If known, what is the typical time span that a patient appears in the dataset (follow up period)
+      title: Physical Sample Availability
+      "$comment": No standard identified. Used enumeration from the UK Tissue Directory.
+      examples:
+      - BONE MARROW
+      items:
+      description: Availability of physical samples associated with the dataset.
+        If samples are available, please indicate the types of samples that are
+        available. More than one type may be provided. If sample are not yet available,
+        please provide “AVAILABILITY TO BE CONFIRMED”. If samples are not available,
+        then please provide “NOT AVAILABLE”.
+      anyOf:
+      - "$ref": "#/definitions/commaSeparatedValues"
+      - type: array
+        contains:
+          "$ref": "#/definitions/physicalSampleAvailability"
+        uniqueItems: true
+        minItems: 1
+    followUp:
+      "$id": "#/properties/coverage/followUp"
+      title: Followup
+      "$comment": No standard identified
+      default: UNKNOWN
+      description: If known, what is the typical time span that a patient appears
+        in the dataset (follow up period)
+      allOf:
+      - "$ref": "#/definitions/followup"
     pathway:
-        "$id": "#/properties/coverage/pathway"
-        type: string
-        minLength: 5
-        maxLength: 3000
-        pattern: "/^.{5,3000}$"
-        title: The short description
-        description: A free-text description of the record.
+      "$id": "#/properties/coverage/pathway"
+      title: Pathway
+      "$comment": No standard identified
+      description: Please indicate if the dataset is representative of the patient
+          pathway and any limitations the dataset may have with respect to pathway
+          coverage. This could include if the dataset is from a single speciality
+          or area, a single tier of care, linked across two tiers (e.g. primary and
+          secondary care), or an integrated care record covering the whole patient
+          pathway.
+      allOf:
+      - "$ref": "#/definitions/description"
   purpose:
     "$id": "#/properties/purpose"
     "$comment": 'FIXME: Mandatory, but cardinality 0:* Possibly deprecate.'
@@ -522,7 +513,7 @@ properties:
         type: string
     title: The statisticalPopulation schema
     description: An explanation about the purpose of this instance.
-  
+
   conformsTo:
     "$id": "#/properties/conformsTo"
     type: string
@@ -688,33 +679,33 @@ definitions:
     pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
     minLength: 36
     maxLength: 36
-  
+
   eightyCharacters:
     type: string
     minLength: 2
     maxLength: 80
-  
+
   abstractText:
     type: string
     minLength: 5
     maxLength: 255
-  
+
   emailAddress:
     type: string
     format: email
-  
+
   commaSeparatedValues:
     type: string
     pattern: "([^,]+)"
-  
-  numericRange:
+
+  ageRange:
     type: string
-    pattern: "\\d{1,3}-\\d{1,3}"
-  
+    pattern: "/(150|1[0-4][0-9]|[0-9]|[1-8][0-9]|9[0-9])-(150|1[0-4][0-9]|[0-9]|[1-8][0-9]|9[0-9])/"
+
   doi:
     type: string
     pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
-  
+
   controlledVocabulary:
     type: string
     enum:
@@ -753,7 +744,7 @@ definitions:
     - 'RXNORM EXTENSION'
     - 'SPL'
     - 'OTHER'
-  
+
   conformsTo:
     type: string
     enum:
@@ -772,7 +763,7 @@ definitions:
     - 'CDISC'
     - 'LOCAL'
     - 'OTHER'
-  
+
   physicalSampleAvailability:
     type: string
     enum:
@@ -797,7 +788,16 @@ definitions:
     - 'URINE'
     - 'WHOLE BLOOD'
     - 'AVAILABILITY TO BE CONFIRMED'
-  
+
+  followup:
+    type: string
+    enum:
+    - 0-6 MONTHS
+    - 6-12 MONTHS
+    - 1-10 YEARS
+    - MORE 10 YEARS
+    - UNKNOWN
+
   periodicity:
     type: string
     enum:
@@ -815,3 +815,7 @@ definitions:
     - IRREGULAR
     - CONTINUOUS
 
+  description:
+    type: string
+    minLength: 5
+    maxLength: 3000

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -819,3 +819,8 @@ definitions:
     type: string
     minLength: 5
     maxLength: 3000
+
+  url:
+    type: string
+    format: uri
+


### PR DESCRIPTION
# RFC D04: Dataset v2 - Coverage Section
## Summary & Motivation:
This RFC introduces a new property object called `coverage` that will be used to replace the `physicalSampleAvailability`, `geographicCoverage` and `ageBand` properties and introduce two new properties of the coverage object - `followup` and `pathway`.

### Authors:
- A. Milward (MetadataWorks)
- D. Milward (MetadataWorks)
- S. Varma (HDR UK)

## Detailed List Of Changes:
This RFC is limited to the coverage section of the new specification which is listed below:

**New/Modified Definitions**:
- **`ageRange`**:
  - Replaces the `numericRange`definition
  - Pattern updated to `/(150|1[0-4][0-9]|[0-9]|[1-8][0-9]|9[0-9])-(150|1[0-4][0-9]|[0-9]|[1-8][0-9]|9[0-9])/`
- **`coverage`**:
  - **`physicalSampleAvailability`**: Availability of physical samples associated with the dataset
  - `spatial`: The geographical area covered by the dataset
  - `typicalAgeRange`: The age range of participants in the dataset in format [min]-[max]
  - `followup`: Typical time span that a patient appears in the dataset (follow up period)
  - `pathway`: Indicate if the dataset is representative of the patient pathway and any restrictions

**Required Properties**:
- **`coverage`**:
  - New required object property defined by the new `coverage` definition

## Breaking Changes:
- **`coverage`**:
  - New required property
- **`physicalSampleAvailability`**:
  - Property moved as a sub-property of the `coverage` object
- **`geographicCoverage`**:
  - Property renamed to `spatial` sub-property of `coverage` object
- **`ageBand`**:
  - Property renamed to `typicalAgeRange` sub-property of `coverage` object


## Unresolved Questions:
- **`coverage`**:
  - Do we need to have this a separate section? 