### PR TITLE
RFC D06: Dataset v2 - Accessibility Section

### DIFF
--- a/schema/dataset/latest/dataset.schema.json
+++ b/schema/dataset/latest/dataset.schema.json
@@ -1,335 +1,759 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/HDRUK/schemata/master/schema/dataset/dataset.schema.json",
+  "$id": "http://healthdatagateway.org/schema/dataset.json",
   "type": "object",
   "title": "HDR UK Dataset",
   "description": "HDR UK Dataset Schema",
-  "version": "1.1.7",
   "required": [
     "id",
+    "identifiers",
     "title",
     "abstract",
     "publisher",
     "contactPoint",
     "accessRights",
+    "shortDescription",
+    "physicalSampleAvailability",
     "accessRequestCost",
     "dataController",
     "license",
-    "periodicity",
+    "accrualPeriodicity",
     "datasetStartDate",
     "jurisdiction",
     "populationType",
     "statisticalPopulation",
-    "physicalSampleAvailability",
     "keywords",
     "conformsTo",
     "language",
     "format",
     "creator",
-    "doi",
     "usageRestrictions"
   ],
   "additionalProperties": true,
   "properties": {
-    "id": {
-      "$id": "#/properties/id",
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-      "minLength": 36,
-      "maxLength": 36,
-      "title": "Dataset identifier",
-      "description": "Dataset identifier"
-    },
-    "identifier": {
-      "$id": "#/properties/identifier",
-      "$comment": "FIX SPEC: Conforms to spec, but this MAY be an array of strings. FIXME: Rename to local identifier",
-      "title": "Local dataset identifier",
-      "description": "Local dataset identifier",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
+    "summary": {
+      "id": {
+        "$id": "#/properties/summary/id",
+        "type": "string",
+        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+        "minLength": 36,
+        "maxLength": 36,
+        "title": "Dataset identifier",
+        "description": "Dataset identifier"
+      },
+      "identifier": {
+        "$id": "#/properties/summary/identifier",
+        "$comment": "FIX SPEC: Conforms to spec, but this MAY be an array of strings. FIXME: Rename to local identifier",
+        "anyOf": [
+          {
             "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
-        }
-      ]
+        ],
+        "title": "Local dataset identifier",
+        "description": "Local dataset identifier"
+      },
+      "name": {
+        "$id": "#/properties/summary/name",
+        "$comment": "using name from schema.org, title is reserved word in json schema",
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 80,
+        "title": "title",
+        "description": "Name of the dataset limited to 80 characters. It should provide a short description of the dataset and be unique across the gateway. If your title is not unique, please add a prefix with your organisation name or identifier to differentiate it from other datasets within the Gateway. Please avoid acronyms wherever possible. Good titles should summarise the content of the dataset and if relevant, the region the dataset covers."
+      },
+      "abstract": {
+        "$id": "#/properties/summary/abstract",
+        "type": "string",
+        "minLength": 5,
+        "maxLength": 255,
+        "title": "Dataset abstract",
+        "description": "Provide a clear and brief descriptive signpost for researchers who are searching for data that may be relevant to their research. The abstract should allow the reader to determine the scope of the data collection and accurately summarise its content. The optimal length is one paragraph (limited to 255 characters) and effective abstracts should avoid long sentences and abbreviations where possible"
+      },
+      "publisher": {
+        "$id": "#/properties/summary/publisher",
+        "$comment": "Conforms to spec, but this MAY be an an object of organisation",
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 80,
+        "title": "Dataset publisher",
+        "description": "This is the organisation responsible for running or supporting the data access request process, as well as publishing and maintaining the metadata. In most this will be the same as the HDR UK Organisation (Hub or Alliance Member). However, in some cases this will be different i.e. Tissue Directory are an HDR UK Gateway organisation but coordinate activities across a number of data publishers i.e. Cambridge Blood and Stem Cell Biobank."
+      },
+      "contactPoint": {
+        "$id": "#/properties/summary/contactPoint",
+        "type": "string",
+        "format": "email",
+        "title": "The contactPoint schema",
+        "description": "An explanation about the purpose of this instance."
+      },
+      "keywords": {
+        "$id": "#/properties/summary/keywords",
+        "$comment": "Conforms to spec, but this MAY be an array of strings",
+        "anyOf": [
+          {
+            "type": "string",
+            "pattern": "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+            }
+          }
+        ],
+        "type": "string",
+        "pattern": "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*",
+        "title": "The keywords schema",
+        "description": "An explanation about the purpose of this instance."
+      },
+      "doiName": {
+        "$id": "#/properties/summary/doiName",
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "In Progress"
+            ]
+          },
+          {
+            "type": "string",
+            "pattern": "^10.\\\\d{4,9}/[-._;()/:a-zA-Z0-9]+$",
+            "title": "Digital Object Identifier",
+            "description": "All HDR UK registered datasets should either have a Digital Object Identifier (DOI) or be working towards obtaining one. If a DOI is available, please provide the DOI."
+          }
+        ]
+      }
     },
-    "title": {
-      "$id": "#/properties/title",
-      "title": "Dataset title",
-      "description": "Name of the dataset limited to 80 characters. It should provide a short description of the dataset and be unique across the gateway. If your title is not unique, please add a prefix with your organisation name or identifier to differentiate it from other datasets within the Gateway. Please avoid acronyms wherever possible. Good titles should summarise the content of the dataset and if relevant, the region the dataset covers.",
-      "type": "string",
-      "minLength": 2,
-      "maxLength": 80
-    },
-    "abstract": {
-      "$id": "#/properties/abstract",
-      "title": "Dataset abstract",
-      "description": "Provide a clear and brief descriptive signpost for researchers who are searching for data that may be relevant to their research. The abstract should allow the reader to determine the scope of the data collection and accurately summarise its content. The optimal length is one paragraph (limited to 255 characters) and effective abstracts should avoid long sentences and abbreviations where possible",
-      "type": "string",
-      "minLength": 5,
-      "maxLength": 255
-    },
-    "publisher": {
-      "$id": "#/properties/publisher",
-      "$comment": "Conforms to spec, but this MAY be an an object of organisation",
-      "title": "Dataset publisher",
-      "description": "This is the organisation responsible for running or supporting the data access request process, as well as publishing and maintaining the metadata. In most this will be the same as the HDR UK Organisation (Hub or Alliance Member). However, in some cases this will be different i.e. Tissue Directory are an HDR UK Gateway organisation but coordinate activities across a number of data publishers i.e. Cambridge Blood and Stem Cell Biobank.",
-      "type": "string",
-      "minLength": 2,
-      "maxLength": 80
-    },
-    "contactPoint": {
-      "$id": "#/properties/contactPoint",
-      "title": "The contactPoint schema",
-      "description": "An explanation about the purpose of this instance.",
-      "type": "string",
-      "format": "email"
-    },
-    "accessRights": {
-      "$id": "#/properties/accessRights",
-      "$comment": "FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality is 1:*",
-      "title": "The accessRights schema",
-      "description": "The URL of a webpage where the data access request process and/or guidance is provided. If there is more than one access process i.e. industry vs academic please provide both. If such a resource or the underlying process doesn’t exist, please provide “In Progress”, until both the process and the documentation are ready.",
-      "anyOf": [
-        {
-          "type": "string",
-          "pattern": "^In Progress$"
-        },
-        {
-          "type": "string",
-          "format": "uri"
-        },
-        {
-          "type": "array",
-          "items": {
+    "documentation": {
+      "shortDescription": {
+        "$id": "#/properties/documentation/shortDescription",
+        "type": "string",
+        "minLength": 5,
+        "maxLength": 3000,
+        "pattern": "/^.{5,3000}$",
+        "title": "The short description",
+        "description": "A free-text description of the record."
+      },
+      "additionalDocumentation": {
+        "$id": "#/properties/documentation/additionalDocumentation",
+        "type": "string",
+        "pattern": "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$",
+        "title": "Digital Object Identifier",
+        "description": "All HDR UK registered datasets should either have a Digital Object Identifier (DOI) or be working towards obtaining one. If a DOI is available, please provide the DOI."
+      },
+      "additionalMedia": {
+        "$id": "#/properties/documentation/additionalMedia",
+        "$comment": "FIXME: Conforms to spec, but this SHOULD to be an array of URIs as cardinality 0:*",
+        "anyOf": [
+          {
             "type": "string",
             "format": "uri"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            }
           }
-        }
-      ]
+        ],
+        "title": "The media schema",
+        "description": "Please provide any media associated with the Gateway Organisation using a valid URI. This is an opportunity to provide additional context that could be useful for researchers wanting to undestand more about the dataset and its relevance to their research question. The following formats will be accepted .jpg, .png or .svg, .pdf, .xslx or .docx."
+      },
+      "isPartOf": {
+        "$id": "#/properties/documentation/isPartOf",
+        "$comment": "Conforms to spec, but this MAY be an array of groups",
+        "type": "string",
+        "title": "The group schema",
+        "description": "An explanation about the purpose of this instance."
+      }
     },
-    "group": {
-      "$id": "#/properties/group",
-      "$comment": "Conforms to spec, but this MAY be an array of groups",
-      "title": "The group schema",
-      "description": "An explanation about the purpose of this instance.",
-      "type": "string"
+    "coverage": {
+      "spatial": {
+        "$id": "#/properties/coverage/spatial",
+        "$comment": "FIXME: Update to geoname pattern",
+        "type": "string",
+        "format": "uri",
+        "title": "The geographicCoverage schema",
+        "description": "The geographical area covered by the dataset.",
+        "default": "",
+        "examples": [
+          "GB"
+        ]
+      },
+      "typicalAgeRange": {
+        "$id": "#/properties/coverage/TypicalAgeRange",
+        "$comment": "FIXME: Rename MDC response to ageRange according to spec",
+        "type": "string",
+        "pattern": "\\d{1,3}-\\d{1,3}",
+        "title": "TypicalAgeRange",
+        "description": "Please indicate the age range in whole years of participants in the dataset. Please provide range in the following format ‘[min age] – [max age]’ where both the minimum and maximum are whole numbers (integers)."
+      },
+      "physicalSampleAvailability": {
+        "$id": "#/properties/coverage/physicalSampleAvailability",
+        "type": "string",
+        "enum": [
+          "Not Available",
+          "Bone Marrow",
+          "Cancer Cell Lines",
+          "Core Biopsy",
+          "CDNA/MRNA",
+          "DNA",
+          "Faeces",
+          "Immortalized Cel Lines",
+          "MicroRNA",
+          "Peripheral Blood Cells",
+          "Plasma",
+          "PM Tissue",
+          "Primary Cells",
+          "RNA",
+          "Saliva",
+          "Serum",
+          "Swabs",
+          "Tissue",
+          "Urine",
+          "Whole Blood",
+          "Availability To Be Confirmed"
+        ],
+        "title": "The physicalSampleAvailability schema",
+        "description": "Availability of physical samples associated with the dataset. If samples are available, please indicate the types of samples that are available.",
+        "default": "",
+        "examples": [
+          "Not Available"
+        ]
+      },
+      "followUp": {
+        "$id": "#/properties/coverage/followUp",
+        "type": "string",
+        "enum": [
+          "0 - 6 MONTHS",
+          "6 - 12 MONTHS",
+          "1 - 10 YEARS",
+          "greater than 10 YEARS",
+          "UNKNOWN"
+        ],
+        "title": "Follow Up",
+        "description": "If known, what is the typical time span that a patient appears in the dataset (follow up period)"
+      },
+      "pathway": {
+        "$id": "#/properties/coverage/pathway",
+        "type": "string",
+        "minLength": 5,
+        "maxLength": 3000,
+        "pattern": "/^.{5,3000}$",
+        "title": "The short description",
+        "description": "A free-text description of the record."
+      }
     },
-    "description": {
-      "$id": "#/properties/description",
-      "title": "The description schema",
-      "description": "A free-text account of the record. An html account of the data that provides context and scope of the data (limited to 50,000 characters) and/or a resolvable URL that describes the dataset.",
-      "anyOf": [
-        {
-          "type": "string",
-          "minLength": 5,
-          "maxLength": 50000
+    "provenance": {
+      "origin": {
+        "properties": null,
+        "purpose": {
+          "$id": "#/properties/provenance/orgin/purpose",
+          "$comment": "FIXME: Mandatory, but cardinality 0:* Possibly deprecate.",
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Study",
+                "Disease Registry",
+                "Trial",
+                "Care",
+                "Audit",
+                "Administrative",
+                "Financial",
+                "Other"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "Study",
+                  "Disease Registry",
+                  "Trial",
+                  "Care",
+                  "Audit",
+                  "Administrative",
+                  "Financial",
+                  "Other"
+                ]
+              }
+            }
+          ],
+          "title": "The purpose schema",
+          "description": "Pleases indicate the purpose(s) that the dataset was collected. Multiple purposes may be provided"
         },
-        {
-          "type": "string",
-          "format": "uri"
-        }
-      ]
-    },
-    "media": {
-      "$id": "#/properties/media",
-      "$comment": "FIXME: Conforms to spec, but this SHOULD to be an array of URIs as cardinality 0:*",
-      "title": "The media schema",
-      "description": "Please provide any media associated with the Gateway Organisation using a valid URI. This is an opportunity to provide additional context that could be useful for researchers wanting to undestand more about the dataset and its relevance to their research question. The following formats will be accepted .jpg, .png or .svg, .pdf, .xslx or .docx.",
-      "anyOf": [
-        {
-          "type": "string",
-          "format": "uri"
+        "source": {
+          "$id": "#/properties/provenance/orgin/source",
+          "$comment": "FIXME: Mandatory, but cardinality 0:* Possibly deprecate.",
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Epr",
+                "Electronic Survey",
+                "Lims",
+                "Paper Based",
+                "Freetext Nlp",
+                "Machine Generated"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "Epr",
+                  "Electronic Survey",
+                  "Lims",
+                  "Paper Based",
+                  "Freetext Nlp",
+                  "Machine Generated"
+                ]
+              }
+            }
+          ],
+          "title": "The source schema",
+          "description": "Pleases indicate the source(s) that the dataset was collected. Multiple source(s) may be provided"
         },
-        {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "format": "uri"
-          }
+        "collectionSituation": {
+          "$id": "#/properties/provenance/orgin/collectionSituation",
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "CLINIC",
+                "PRIMARY CARE",
+                "ACCIDENT AN EMERGENCY",
+                "OUTPATIENTS",
+                "IN-PATIENTS",
+                "SERVICES",
+                "COMMUNITY",
+                "HOME",
+                "PRIVATE",
+                "PHARMACY",
+                "OTHER"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "CLINIC",
+                  "PRIMARY CARE",
+                  "ACCIDENT AN EMERGENCY",
+                  "OUTPATIENTS",
+                  "IN-PATIENTS",
+                  "SERVICES",
+                  "COMMUNITY",
+                  "HOME",
+                  "PRIVATE",
+                  "PHARMACY",
+                  "OTHER"
+                ]
+              }
+            }
+          ],
+          "title": "The purpose schema",
+          "description": "Pleases indicate the purpose(s) that the dataset was collected. Multiple purposes may be provided - see https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/FieldLevelDocumentation/schemas/datacollection_xsd/elements/CollectionSituation.html"
         }
-      ]
-    },
-    "purpose": {
-      "$id": "#/properties/purpose",
-      "$comment": "FIXME: Mandatory, but cardinality 0:* Possibly deprecate.",
-      "title": "The purpose schema",
-      "description": "Pleases indicate the purpose(s) that the dataset was collected. Multiple purposes may be provided",
-      "anyOf": [
-        {
+      },
+      "temporal": {
+        "accrualPeriodicity": {
+          "$id": "#/properties/provenance/temporal/accrualPeriodicity",
           "type": "string",
           "enum": [
-            "Study",
-            "Disease Registry",
-            "Trial",
-            "Care",
-            "Audit",
-            "Administrative",
-            "Financial"
-          ]
+            "Static",
+            "Annual",
+            "Biannual",
+            "Biennial",
+            "Quarterly",
+            "Bimonthly",
+            "Monthly",
+            "Biweekly",
+            "Daily",
+            "Irregular",
+            "Continuous"
+          ],
+          "title": "Periodicity",
+          "$comment": "dct:accrualPeriodicity",
+          "description": "Please indicate the frequency of publishing. If a dataset is published regularly please choose a publishing periodicity from the constrained list and indicate the next release date. When the release date becomes historical, a new release date will be calculated based on the publishing periodicity. If a dataset has been published and will remain static please indicate that it is static and indicated when it was released. If a dataset is released on an irregular basis or “on-demand” please indicate that it is Irregular and leave release date as null. If a dataset can be published in real-time or near-real-time please indicate that it is continuous and leave release date as null. Notes: see https://www.dublincore.org/specifications/dublin-core/collection-description/frequency/",
+          "$ref": "#/definitions/periodicity",
+          "default": ""
         },
-        {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "Study",
-              "Disease Registry",
-              "Trial",
-              "Care",
-              "Audit",
-              "Administrative",
-              "Financial"
-            ]
-          }
-        }
-      ]
-    },
-    "source": {
-      "$id": "#/properties/source",
-      "$comment": "FIXME: Mandatory, but cardinality 0:* Possibly deprecate.",
-      "title": "The source schema",
-      "description": "Pleases indicate the source(s) that the dataset was collected. Multiple source(s) may be provided",
-      "anyOf": [
-        {
+        "distibutionReleaseDate": {
+          "$id": "#/properties/provenance/temporal/distibutionReleaseDate",
+          "type": "string",
+          "format": "date-time",
+          "title": "The releaseDate schema",
+          "description": "Date of the latest release of the dataset. If this is a regular release i.e. quarterly, or this is a static dataset please complete this alongside Periodicity."
+        },
+        "endDate": {
+          "$id": "#/properties/provenance/temporal/endDate",
+          "type": "string",
+          "format": "date",
+          "title": "The datasetEndDate schema",
+          "description": "The end of the time period that the dataset provides coverage for."
+        },
+        "startDate": {
+          "$id": "#/properties/provenance/temporal/startDate",
+          "type": "string",
+          "format": "date",
+          "title": "The datasetStartDate schema",
+          "description": "The start of the time period that the dataset provides coverage for."
+        },
+        "timeLag": {
+          "$id": "#/properties/provenance/temporal/timeLag",
           "type": "string",
           "enum": [
-            "Epr",
-            "Electronic Survey",
-            "Lims",
-            "Paper Based",
-            "Freetext Nlp",
-            "Machine Generated"
-          ]
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "Epr",
-              "Electronic Survey",
-              "Lims",
-              "Paper Based",
-              "Freetext Nlp",
-              "Machine Generated"
-            ]
-          }
+            "less than 1 WEEK",
+            "1-2 WEEKS",
+            "2-4 WEEKS",
+            "1-2 MONTHS",
+            "2-6 MONTHS",
+            "greater than 6 MONTHS",
+            "VARIABLE",
+            "NA"
+          ],
+          "title": "Time Lag",
+          "description": "Please indicate the typical time-lag between an event and the data for that event appearing in the dataset."
         }
-      ]
+      }
     },
-    "setting": {
-      "$id": "#/properties/setting",
-      "$comment": "FIXME: Mandatory, but cardinality 0:*. Possibly deprecate.",
-      "title": "The setting schema",
-      "description": "Pleases indicate the setting(s) where data was collected. Multiple settings may be provided.",
-      "anyOf": [
-        {
+    "accessibility": {
+      "usage": {
+        "dataUseLimitation": {
+          "$id": "#/properties/accessibility/usage/dataUseLimitation",
           "type": "string",
           "enum": [
-            "Clinic",
-            "Primary Care",
-            "Accident and Emergency",
-            "Outpatients",
-            "In-Patients",
-            "Services",
-            "Community",
-            "Home",
-            "Private",
-            "Pharmacy"
-          ]
+            "GENERAL RESEARCH USE",
+            "GENETIC STUDIES ONLY",
+            "NO GENERAL METHODS RESEARCH",
+            "NO RESTRICTION",
+            "RESEARCH SPECIFIC RESTRICTIONS",
+            "RESEARCH USE ONLY",
+            "NO LINKAGE"
+          ],
+          "title": "Data Use Limitation",
+          "description": "An indication of consent permissions for datasets and/or materials, and relates to the purposes for which datasets and/or material might be removed, stored or used."
         },
-        {
-          "type": "array",
-          "items": {
+        "dataUseRequirements": {
+          "$id": "#/properties/accessibility/usage/dataUseRequirements",
+          "type": "string",
+          "enum": [
+            "COLLABORATION REQUIRED",
+            "ETHICS APPROVAL REQUIRED",
+            "GEOGRAPHICAL RESTRICTIONS",
+            "INSTITUTION SPECIFIC RESTRICTIONS",
+            "NOT FOR PROFIT USE",
+            "PROJECT SPECIFIC RESTRICTIONS",
+            "PUBLICATION MORATORIUM",
+            "PUBLICATION REQUIRED",
+            "RETURN TO DATABASE OR RESOURCE",
+            "TIME LIMIT ON USE",
+            "USER SPECIFIC RESTRICTION"
+          ],
+          "title": "Data Use Limitation",
+          "description": "An indication of consent permissions for datasets and/or materials, and relates to the purposes for which datasets and/or material might be removed, stored or used."
+        },
+        "resourceCreator": {
+          "$id": "#/properties/accessibility/usage/resourceCreator",
+          "type": "string",
+          "title": "The creator schema",
+          "description": "Please provide the text that you would like included as part of any citation that credits this dataset. This is typically just the name of the publisher.   No employee details should be provided."
+        },
+        "investigations": {
+          "type": "string",
+          "pattern": "^\\\\((([A-Za-z]{3,9}:(?:\\/\\/)?)(?:[-;:&=\\+\\$,\\w]+@)?[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\\+\\$,\\w]+@)[A-Za-z0-9.-]+)((?:\\/[\\+~%\\/.\\w-_]*)?\\??(?:[-\\+=&;%@.\\w_]*)#?(?:[\\w]*))?)",
+          "title": "Investigations",
+          "description": "Please provide a link to any active projects that are using the dataset."
+        },
+        "isReferencedBy": {
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^10.\\\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^10.\\\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
+              }
+            }
+          ],
+          "title": "Is Referenced By",
+          "description": "The keystone paper associated with the dataset. Also include a list of known citations, if available and should be links to existing resources where the dataset has been used or referenced."
+        }
+      },
+      "access": {
+        "accessRights": {
+          "$id": "#/properties/accessibility/access/accessRights",
+          "$comment": "FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality is 1:*",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^In Progress$"
+            },
+            {
+              "type": "string",
+              "format": "uri"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          ],
+          "title": "The accessRights schema",
+          "description": "The URL of a webpage where the data access request process and/or guidance is provided. If there is more than one access process i.e. industry vs academic please provide both. If such a resource or the underlying process doesn’t exist, please provide “In Progress”, until both the process and the documentation are ready."
+        },
+        "accessService": {
+          "$id": "#/properties/accessibility/access/accessService",
+          "type": "string",
+          "pattern": "^.{5,5000}$",
+          "title": "Access Service",
+          "description": "Please provide a brief description of the environment where data can be accessed by researchers. If no environment is currently available, please indicate the current plans and timelines when the data will be made available through an access environment or process."
+        },
+        "deliveryLeadTime": {
+          "$id": "#/properties/accessibility/access/deliveryLeadTime",
+          "type": "string",
+          "enum": [
+            "less than 1 Week",
+            "1-2 Weeks",
+            "2-4 Weeks",
+            "1-2 Months",
+            "2-6 Months",
+            "greater than 6 Months",
+            "Other"
+          ],
+          "title": "The accessRequestDuration schema",
+          "description": "Please provide an indication of the typical processing times based on the types of requests typically received."
+        },
+        "accessRequests": {
+          "$id": "#/properties/accessibility/access/accessRequests",
+          "type": "integer",
+          "title": "Access Requests",
+          "description": "Please indicate the number of data access requests that have been received for the dataset."
+        },
+        "jurisdiction": {
+          "$id": "#/properties/jurisdiction",
+          "$comment": "FIXME: Add ISO 3166-2 Subdivision code pattern",
+          "type": "string",
+          "pattern": "^[A-Z]{2}(-[A-Z]{2,3})?$",
+          "title": "The jurisdiction schema",
+          "description": "Please use country code from ISO 3166-1 country codes and the associated ISO 3166-2 for regions, cities, states etc. for the country/state under whose laws the data subjects’ data is collected, processed and stored."
+        },
+        "dataController": {
+          "$id": "#/properties/accessibility/access/dataController",
+          "type": "string",
+          "title": "Data Controller",
+          "description": "Data Controller means a person/entity who (either alone or jointly or in common with other persons/entities) determines the purposes for which and the way any Data Subject data, specifically personal data or are to be processed."
+        },
+        "dataProcessor": {
+          "$id": "#/properties/accessibility/access/dataProcessor",
+          "type": "string",
+          "title": "Data Processor",
+          "description": "A Data Processor, in relation to any Data Subject data, specifically personal data, means any person/entity (other than an employee of the data controller) who processes the data on behalf of the data controller."
+        },
+        "formatAndStandards": {
+          "vocabularyEncodingScheme": {
+            "$id": "#/properties/properties/accessibility/formatAndStandards/vocabularyEncodingScheme",
+            "$comment": "FIXME: Confroms to spec, but MAY be a list of strings",
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "LOCAL",
+                  "OPCS4",
+                  "READ",
+                  "SNOMED CT",
+                  "SNOMED RT",
+                  "DM+D",
+                  "NHS NATIONAL CODES",
+                  "ODS",
+                  "LOINC",
+                  "ICD10",
+                  "ICD10CM",
+                  "ICD10PCS",
+                  "ICD9CM",
+                  "ICD9",
+                  "ICDO3",
+                  "AMT",
+                  "APC",
+                  "ATC",
+                  "CIEL",
+                  "HPO",
+                  "CPT4",
+                  "DPD",
+                  "DRG",
+                  "HEMONIC",
+                  "JMDC",
+                  "KCD7",
+                  "MULTUM",
+                  "NAACCR",
+                  "NDC",
+                  "NDFRT",
+                  "OXMIS",
+                  "RXNORM",
+                  "RXNORM EXTENSION",
+                  "SPL",
+                  "OTHER"
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "LOCAL",
+                    "OPCS4",
+                    "READ",
+                    "SNOMED CT",
+                    "SNOMED RT",
+                    "DM+D",
+                    "NHS NATIONAL CODES",
+                    "ODS",
+                    "LOINC",
+                    "ICD10",
+                    "ICD10CM",
+                    "ICD10PCS",
+                    "ICD9CM",
+                    "ICD9",
+                    "ICDO3",
+                    "AMT",
+                    "APC",
+                    "ATC",
+                    "CIEL",
+                    "HPO",
+                    "CPT4",
+                    "DPD",
+                    "DRG",
+                    "HEMONIC",
+                    "JMDC",
+                    "KCD7",
+                    "MULTUM",
+                    "NAACCR",
+                    "NDC",
+                    "NDFRT",
+                    "OXMIS",
+                    "RXNORM",
+                    "RXNORM EXTENSION",
+                    "SPL",
+                    "OTHER"
+                  ]
+                }
+              }
+            ],
+            "title": "The controlledVocabulary schema",
+            "description": "List any relevant terminologies / ontologies / controlled vocabularies, such as ICD 10 Codes, NHS Data Dictionary National Codes or SNOMED CT International, that are being used by the dataset.",
+            "default": "",
+            "examples": [
+              "See ConformsTo"
+            ]
+          },
+          "conformsTo": {
+            "$id": "#/properties/conformsTo",
             "type": "string",
             "enum": [
-              "Clinic",
-              "Primary Care",
-              "Accident and Emergency",
-              "Outpatients",
-              "In-Patients",
-              "Services",
-              "Community",
-              "Home",
-              "Private",
-              "Pharmacy"
-            ]
+              "HL7 FHIR",
+              "HL7 V2",
+              "HL7 CDA",
+              "HL7 CCOW",
+              "LOINC",
+              "DICOM",
+              "I2B2",
+              "IHE",
+              "OMOP",
+              "OPENEHR",
+              "SENTINEL",
+              "PCORNET",
+              "LOCAL",
+              "CDISC",
+              "OTHER"
+            ],
+            "title": "The conformsTo schema",
+            "description": "An explanation about the purpose of this instance."
+          },
+          "language": {
+            "$id": "#/properties/language",
+            "$comment": "FIXME: Conforms to spec, but may be a list of strings given cardinality 1:*. Validate against external list of languages. Resources defined by the Library of Congress (ISO 639-1, ISO 639-2) SHOULD be used.",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ],
+            "title": "The language schema",
+            "description": "This should list all the languages in which the dataset metadata and underlying data is made available."
+          },
+          "format": {
+            "$id": "#/properties/format",
+            "$comment": "FIXME: Conforms to spec, but may be a list of strings given cardinality 1:*. Validate against external list of formats, e.g. https://www.iana.org/assignments/media-types/media-types.xhtml",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ],
+            "title": "The format schema",
+            "description": "If multiple formats are available please specify."
           }
         }
-      ]
+      }
     },
     "releaseDate": {
       "$id": "#/properties/releaseDate",
-      "title": "The releaseDate schema",
-      "description": "An explanation about the purpose of this instance.",
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "title": "The releaseDate schema",
+      "description": "An explanation about the purpose of this instance."
     },
     "accessRequestCost": {
       "$id": "#/properties/accessRequestCost",
-      "title": "The accessRequestCost schema",
-      "description": "An explanation about the purpose of this instance.",
-      "type": "string"
-    },
-    "accessRequestDuration": {
-      "$id": "#/properties/accessRequestDuration",
-      "title": "The accessRequestDuration schema",
-      "description": "Please provide an indication of the typical processing times based on the types of requests typically received.",
       "type": "string",
-      "enum": [
-        "<1 Week",
-        "1-2 Weeks",
-        "2-4 Weeks",
-        "1-2 Months",
-        "2-6 Months",
-        ">6 Months",
-        "Other"
-      ]
+      "title": "The accessRequestCost schema",
+      "description": "An explanation about the purpose of this instance."
     },
     "accessEnvironment": {
       "$id": "#/properties/accessEnvironment",
-      "title": "The accessEnvironment schema",
-      "description": "Please provide a brief description of the data access environment that is currently available to researchers.",
       "type": "string",
       "minLength": 5,
-      "maxLength": 5000
-    },
-    "usageRestrictions": {
-      "$id": "#/properties/usageRestrictions",
-      "$comment": "FIXME: Missing from Onboarding tool, so not captured",
-      "title": "The usageRestrictions schema",
-      "description": "Please provide a description of any usage restrictions of key terms and conditions under which access to the dataset is provided.",
-      "anyOf": [
-        {
-          "type": "string",
-          "minLength": 5,
-          "maxLength": 50000
-        },
-        {
-          "type": "string",
-          "enum": [
-            "In Progress"
-          ]
-        }
-      ]
+      "maxLength": 5000,
+      "title": "The accessEnvironment schema",
+      "description": "Please provide a brief description of the data access environment that is currently available to researchers."
     },
     "dataController": {
       "$id": "#/properties/dataController",
-      "title": "The dataController schema",
-      "description": "Data Controller means a person/entity who (either alone or jointly or in common with other persons/entities) determines the purposes for which and the way any Data Subject data, specifically personal data or are to be processed.",
       "type": "string",
       "minLength": 5,
-      "maxLength": 5000
+      "maxLength": 5000,
+      "title": "The dataController schema",
+      "description": "Data Controller means a person/entity who (either alone or jointly or in common with other persons/entities) determines the purposes for which and the way any Data Subject data, specifically personal data or are to be processed."
     },
     "dataProcessor": {
       "$id": "#/properties/dataProcessor",
-      "title": "The dataProcessor schema",
-      "description": "A Data Processor, in relation to any Data Subject data, specifically personal data, means any person/entity (other than an employee of the data controller) who processes the data on behalf of the data controller.",
       "anyOf": [
         {
           "type": "string",
@@ -342,19 +766,19 @@
             "Not Applicable"
           ]
         }
-      ]
+      ],
+      "title": "The dataProcessor schema",
+      "description": "A Data Processor, in relation to any Data Subject data, specifically personal data, means any person/entity (other than an employee of the data controller) who processes the data on behalf of the data controller."
     },
     "license": {
       "$id": "#/properties/license",
+      "type": "string",
       "title": "The license schema",
-      "description": "An explanation about the purpose of this instance.",
-      "type": "string"
+      "description": "An explanation about the purpose of this instance."
     },
     "derivedDatasets": {
       "$id": "#/properties/derivedDatasets",
       "$comment": "FIXME: Conforms to spec, but this SHOULD to be an array of datasets as cardinality 0:*",
-      "title": "The derivedDatasets schema",
-      "description": "Indicate if derived datasets or predefined extracts are available and the type of derivation available.",
       "anyOf": [
         {
           "type": "string",
@@ -374,13 +798,13 @@
             "Not Available"
           ]
         }
-      ]
+      ],
+      "title": "The derivedDatasets schema",
+      "description": "Indicate if derived datasets or predefined extracts are available and the type of derivation available."
     },
     "linkedDataset": {
       "$id": "#/properties/linkedDataset",
       "$comment": "FIXME: If linked $title must start with 'Linked'. FIXME: Conforms to spec, but this SHOULD to be an array of datasets as cardinality 0:*",
-      "title": "The linkedDataset schema",
-      "description": "If applicable, please provide the DOI of other datasets that have previously been linked to this dataset and their availability. If no DOI is available, please provide the title of the datasets that can be linked, where possible using the same title of a dataset previously onboarded.",
       "anyOf": [
         {
           "type": "string",
@@ -400,12 +824,12 @@
             "Not Available"
           ]
         }
-      ]
+      ],
+      "title": "The linkedDataset schema",
+      "description": "If applicable, please provide the DOI of other datasets that have previously been linked to this dataset and their availability. If no DOI is available, please provide the title of the datasets that can be linked, where possible using the same title of a dataset previously onboarded."
     },
     "linkageOpportunity": {
       "$id": "#/properties/linkageOpportunity",
-      "title": "The linkageOpportunity schema",
-      "description": "If applicable, please indicate if there is the opportunity to link this dataset to additional data sources. If possible, please describe the data elements that could be used to link to external data sources i.e. region or postcode could be used to link to open datasets such as air pollution or deprivation indices. In addition, please describe the restricted data elements that cannot be used to link to other datasets.",
       "anyOf": [
         {
           "type": "string"
@@ -418,15 +842,17 @@
           ]
         }
       ],
-      "type": "string"
+      "type": "string",
+      "title": "The linkageOpportunity schema",
+      "description": "If applicable, please indicate if there is the opportunity to link this dataset to additional data sources. If possible, please describe the data elements that could be used to link to external data sources i.e. region or postcode could be used to link to open datasets such as air pollution or deprivation indices. In addition, please describe the restricted data elements that cannot be used to link to other datasets."
     },
     "geographicCoverage": {
       "$id": "#/properties/geographicCoverage",
       "$comment": "FIXME: Update to geoname pattern",
-      "title": "The geographicCoverage schema",
-      "description": "The geographical area covered by the dataset.",
       "type": "string",
       "format": "uri",
+      "title": "The geographicCoverage schema",
+      "description": "The geographical area covered by the dataset.",
       "default": "",
       "examples": [
         "GB"
@@ -434,37 +860,39 @@
     },
     "periodicity": {
       "$id": "#/properties/periodicity",
+      "type": "string",
+      "enum": [
+        "Static",
+        "Annual",
+        "Biennial",
+        "Quaterly",
+        "Bimonthly",
+        "Monthly",
+        "Biweekly",
+        "Daily",
+        "Irregular",
+        "Continious"
+      ],
       "title": "The periodicity schema",
-      "description": "The frequency at which dataset is published.",
-      "$ref": "#/definitions/periodicity"
+      "description": "The frequency at which dataset is published."
     },
     "datasetEndDate": {
       "$id": "#/properties/datasetEndDate",
-      "title": "The datasetEndDate schema",
-      "description": "The end of the time period that the dataset provides coverage for.",
       "type": "string",
-      "format": "date"
+      "format": "date",
+      "title": "The datasetEndDate schema",
+      "description": "The end of the time period that the dataset provides coverage for."
     },
     "datasetStartDate": {
       "$id": "#/properties/datasetStartDate",
+      "type": "string",
+      "format": "date",
       "title": "The datasetStartDate schema",
-      "description": "The start of the time period that the dataset provides coverage for.",
-      "type": "string",
-      "format": "date"
-    },
-    "jurisdiction": {
-      "$id": "#/properties/jurisdiction",
-      "$comment": "FIXME: Add ISO 3166-2 Subdivision code pattern",
-      "title": "The jurisdiction schema",
-      "description": "Please use country code from ISO 3166-1 country codes and the associated ISO 3166-2 for regions, cities, states etc. for the country/state under whose laws the data subjects’ data is collected, processed and stored.",
-      "type": "string",
-      "pattern": "^[A-Z]{2}(-[A-Z]{2,3})?$"
+      "description": "The start of the time period that the dataset provides coverage for."
     },
     "populationType": {
       "$id": "#/properties/populationType",
       "$comment": "FIXME: Check against SNOMED-CT TERMS. Conforms to spec but MAY be array of strings",
-      "title": "The populationType schema",
-      "description": "Please provide a valid SNOMED CT concept that describes the measure within the dataset i.e. participants in a study, modality, or images with certain characteristics.",
       "anyOf": [
         {
           "type": "string"
@@ -475,20 +903,21 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "title": "The populationType schema",
+      "description": "Please provide a valid SNOMED CT concept that describes the measure within the dataset i.e. participants in a study, modality, or images with certain characteristics."
     },
     "disabmiguatingDescription": {
       "$id": "#/properties/disabmiguatingDescription",
-      "$comment": "FIXME: MDC is not populated with this value",
+      "$comment": "FIXME: Rename MDC response to ageRange according to spec",
+      "type": "string",
+      "pattern": "\\d{1,3}-\\d{1,3}",
       "title": "The disabmiguatingDescription schema",
-      "description": "If SNOMED CT term does not provide sufficient detail, please provide a description that disambiguates the population type.",
-      "type": "string"
+      "description": "If SNOMED CT term does not provide sufficient detail, please provide a description that disambiguates the population type."
     },
     "statisticalPopulation": {
       "$id": "#/properties/statisticalPopulation",
       "$comment": "FIXME: Spec calls this Measured Value",
-      "title": "The statisticalPopulation schema",
-      "description": "An explanation about the purpose of this instance.",
       "anyOf": [
         {
           "type": "string"
@@ -499,135 +928,64 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "title": "The statisticalPopulation schema",
+      "description": "An explanation about the purpose of this instance."
     },
     "ageBand": {
       "$id": "#/properties/ageBand",
       "$comment": "FIXME: Rename MDC response to ageRange according to spec",
+      "type": "string",
+      "pattern": "\\d{1,3}-\\d{1,3}",
       "title": "The ageBand schema",
-      "description": "Please indicate the age range in whole years of participants in the dataset. Please provide range in the following format ‘[min age] – [max age]’ where both the minimum and maximum are whole numbers (integers).",
-      "$ref": "#/definitions/numericRange"
+      "description": "Please indicate the age range in whole years of participants in the dataset. Please provide range in the following format ‘[min age] – [max age]’ where both the minimum and maximum are whole numbers (integers)."
     },
     "physicalSampleAvailability": {
       "$id": "#/properties/physicalSampleAvailability",
-      "$comment": "Conforms to spec, but this MAY be an array of strings",
+      "type": "string",
+      "enum": [
+        "Not Available",
+        "Bone Marrow",
+        "Cancer Cell Lines",
+        "Core Biopsy",
+        "CDNA/MRNA",
+        "DNA",
+        "Faeces",
+        "Immortalized Cel Lines",
+        "MicroRNA",
+        "Peripheral Blood Cells",
+        "Plasma",
+        "PM Tissue",
+        "Primary Cells",
+        "RNA",
+        "Saliva",
+        "Serum",
+        "Swabs",
+        "Tissue",
+        "Urine",
+        "Whole Blood",
+        "Availability To Be Confirmed"
+      ],
       "title": "The physicalSampleAvailability schema",
       "description": "Availability of physical samples associated with the dataset. If samples are available, please indicate the types of samples that are available.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/physicalSampleAvailability"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/physicalSampleAvailability"
-          }
-        }
-      ],
       "default": "",
       "examples": [
         "Not Available"
       ]
     },
-    "keywords": {
-      "$id": "#/properties/keywords",
-      "$comment": "Conforms to spec, but this MAY be an array of strings",
-      "title": "The keywords schema",
-      "description": "An explanation about the purpose of this instance.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/commaSeparatedValues"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/commaSeparatedValues"
-          }
-        }
-      ]
-    },
-    "conformsTo": {
-      "title": "The conformsTo schema",
-      "description": "An explanation about the purpose of this instance.",
-      "$id": "#/properties/conformsTo",
-      "$ref": "#/definitions/conformsTo"
-    },
-    "controlledVocabulary": {
-      "$id": "#/properties/controlledVocabulary",
-      "$comment": "FIXME: Confroms to spec, but MAY be a list of strings",
-      "title": "The controlledVocabulary schema",
-      "description": "List any relevant terminologies / ontologies / controlled vocabularies, such as ICD 10 Codes, NHS Data Dictionary National Codes or SNOMED CT International, that are being used by the dataset.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/controlledVocabulary"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/controlledVocabulary"
-          }
-        }
-      ],
-      "default": "",
-      "examples": [
-        "See ConformsTo"
-      ]
-    },
-    "language": {
-      "$id": "#/properties/language",
-      "$comment": "FIXME: Conforms to spec, but may be a list of strings given cardinality 1:*. Validate against external list of languages. Resources defined by the Library of Congress (ISO 639-1, ISO 639-2) SHOULD be used.",
-      "title": "The language schema",
-      "description": "This should list all the languages in which the dataset metadata and underlying data is made available.",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "format": {
-      "$id": "#/properties/format",
-      "$comment": "FIXME: Conforms to spec, but may be a list of strings given cardinality 1:*. Validate against external list of formats, e.g. https://www.iana.org/assignments/media-types/media-types.xhtml",
-      "title": "The format schema",
-      "description": "If multiple formats are available please specify.",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      ]
-    },
     "fileSize": {
       "$id": "#/properties/fileSize",
+      "type": "string",
       "title": "The fileSize schema",
       "description": "An explanation about the purpose of this instance.",
-      "type": "string",
       "default": "",
       "examples": [
         "301MB"
       ]
     },
-    "creator": {
-      "$id": "#/properties/creator",
-      "title": "The creator schema",
-      "description": "Please provide the text that you would like included as part of any citation that credits this dataset. This is typically just the name of the publisher. No employee details should be provided.",
-      "type": "string"
-    },
     "citations": {
       "$id": "#/properties/citations",
       "$comment": "FIXME: Conforms to spec, but may be a list of citation strings",
-      "title": "The citations schema",
-      "description": "Please provide the keystone paper associated with the dataset. Also include a list of known citations, if available and should be links to existing resources where the dataset has been used or referenced.",
       "anyOf": [
         {
           "type": "string"
@@ -638,27 +996,32 @@
             "type": "string"
           }
         }
-      ]
-    },
-    "doi": {
-      "$id": "#/properties/doi",
-      "title": "Digital Object Identifier",
-      "description": "All HDR UK registered datasets should either have a Digital Object Identifier (DOI) or be working towards obtaining one. If a DOI is available, please provide the DOI.",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": [
-            "In Progress"
-          ]
-        },
-        {
-          "type": "string",
-          "pattern": "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
-        }
-      ]
+      ],
+      "title": "The citations schema",
+      "description": "Please provide the keystone paper associated with the dataset. Also include a list of known citations, if available and should be links to existing resources where the dataset has been used or referenced."
     }
   },
   "definitions": {
+    "uuidv4": {
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "minLength": 36,
+      "maxLength": 36
+    },
+    "eightyCharacters": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 80
+    },
+    "abstractText": {
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 255
+    },
+    "emailAddress": {
+      "type": "string",
+      "format": "email"
+    },
     "commaSeparatedValues": {
       "type": "string",
       "pattern": "([^,]+)"
@@ -666,6 +1029,10 @@
     "numericRange": {
       "type": "string",
       "pattern": "\\d{1,3}-\\d{1,3}"
+    },
+    "doi": {
+      "type": "string",
+      "pattern": "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
     },
     "controlledVocabulary": {
       "type": "string",
@@ -757,8 +1124,9 @@
       "type": "string",
       "enum": [
         "STATIC",
-        "ANNUAL",
         "BIENNIAL",
+        "ANNUAL",
+        "BIANNUAL",
         "QUARTERLY",
         "BIMONTHLY",
         "MONTHLY",

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -7,6 +7,8 @@ version: "1.1.7"
 
 required:
 - id
+- version
+- revisions
 - title
 - abstract
 - publisher
@@ -40,6 +42,20 @@ properties:
     maxLength: 36
     title: Dataset identifier
     description: Dataset identifier
+  
+  version:
+    "$id": "#/properties/version"
+    title: Dataset Version
+    description: Dataset metadata version
+    "$ref": "#/definitions/semver"
+    examples:
+    - "1.1.0"
+  
+  revisions:
+    "$id": "#/properties/revisions"
+    title: Dataset Revisions
+    description: Revisions of Dataset metadata
+    "$ref": "#/definitions/revisions"
   
   identifier:
     "$id": "#/properties/identifier"
@@ -596,6 +612,21 @@ definitions:
   numericRange:
     type: string
     pattern: "\\d{1,3}-\\d{1,3}"
+  
+  semver:
+    type: string
+    pattern: "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$"
+  
+  revisions:
+    type: array
+    items:
+      type: object
+      properties:
+        version:
+          "$ref": "#/definitions/semver"
+        url:
+          type: string
+          format: uri
   
   controlledVocabulary:
     type: string

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -614,6 +614,9 @@ definitions:
     pattern: "\\d{1,3}-\\d{1,3}"
   
   semver:
+    title: Semantic Version
+    description: Semantic versioning of the using a dotted numeric format 
+      MAJOR.MINOR.PATCH
     type: string
     pattern: "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$"
   
@@ -621,10 +624,15 @@ definitions:
     type: array
     items:
       type: object
+      required:
+      - version
+      - url
       properties:
         version:
+          description: Semantic Version
           "$ref": "#/definitions/semver"
         url:
+          description: URL endpoint to obtain the version
           type: string
           format: uri
   

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -1,353 +1,668 @@
-"$schema": "http://json-schema.org/draft-07/schema"
-"$id": "https://raw.githubusercontent.com/HDRUK/schemata/master/schema/dataset/dataset.schema.json"
+"$schema": http://json-schema.org/draft-07/schema
+"$id": http://healthdatagateway.org/schema/dataset.json
 type: object
 title: HDR UK Dataset
 description: HDR UK Dataset Schema
-version: "1.1.7"
-
 required:
 - id
-- version
-- revisions
-- issued
-- modified
+- identifiers
 - title
 - abstract
 - publisher
 - contactPoint
 - accessRights
+- shortDescription
+- physicalSampleAvailability
 - accessRequestCost
 - dataController
 - license
-- periodicity
+- accrualPeriodicity
 - datasetStartDate
 - jurisdiction
 - populationType
 - statisticalPopulation
-- physicalSampleAvailability
 - keywords
 - conformsTo
 - language
 - format
 - creator
-- doi
 - usageRestrictions
-
 additionalProperties: true
-
 properties:
-  id:
-    "$id": "#/properties/id"
-    type: string
-    pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-    minLength: 36
-    maxLength: 36
-    title: Dataset identifier
-    description: Dataset identifier
-  
-  version:
-    "$id": "#/properties/version"
-    title: Dataset Version
-    description: Dataset metadata version
-    "$ref": "#/definitions/semver"
-    examples:
-    - "1.1.0"
-  
-  revisions:
-    "$id": "#/properties/revisions"
-    title: Dataset Revisions
-    description: Revisions of Dataset metadata
-    "$ref": "#/definitions/revisions"
-  
-  issued:
-    "$id": "#/properties/issued"
-    title: Creation Date
-    "$comment": 'dcat:issued'
-    description: Dataset Metadata Creation Date
-    type: string
-    format: date-time
-  
-  modified:
-    "$id": "#/properties/modified"
-    title: Modification Date
-    "$comment": 'dcat:modified'
-    description: Dataset Metadata Creation Date
-    type: string
-    format: date-time
-  
-  identifier:
-    "$id": "#/properties/identifier"
-    "$comment": 'FIX SPEC: Conforms to spec, but this MAY be an array of strings.
-      FIXME: Rename to local identifier'
-    title: Local dataset identifier
-    description: Local dataset identifier
-    anyOf:
-    - type: string
-    - type: array
-      items:
-        type: string
-  
-  title:
-    "$id": "#/properties/title"
-    title: Dataset title
-    description: Name of the dataset limited to 80 characters. It should provide a
-      short description of the dataset and be unique across the gateway. If your title
-      is not unique, please add a prefix with your organisation name or identifier
-      to differentiate it from other datasets within the Gateway. Please avoid acronyms
-      wherever possible. Good titles should summarise the content of the dataset and
-      if relevant, the region the dataset covers.
-    type: string
-    minLength: 2
-    maxLength: 80
-  
-  abstract:
-    "$id": "#/properties/abstract"
-    title: Dataset abstract
-    description: Provide a clear and brief descriptive signpost for researchers who
-      are searching for data that may be relevant to their research. The abstract
-      should allow the reader to determine the scope of the data collection and accurately
-      summarise its content. The optimal length is one paragraph (limited to 255 characters)
-      and effective abstracts should avoid long sentences and abbreviations where
-      possible
-    type: string
-    minLength: 5
-    maxLength: 255
-  
-  publisher:
-    "$id": "#/properties/publisher"
-    "$comment": Conforms to spec, but this MAY be an an object of organisation
-    title: Dataset publisher
-    description: This is the organisation responsible for running or supporting the
-      data access request process, as well as publishing and maintaining the metadata.
-      In most this will be the same as the HDR UK Organisation (Hub or Alliance Member).
-      However, in some cases this will be different i.e. Tissue Directory are an HDR
-      UK Gateway organisation but coordinate activities across a number of data publishers
-      i.e. Cambridge Blood and Stem Cell Biobank.
-    type: string
-    minLength: 2
-    maxLength: 80
-  
-  contactPoint:
-    "$id": "#/properties/contactPoint"
-    title: The contactPoint schema
-    description: An explanation about the purpose of this instance.
-    type: string
-    format: email
-  
-  accessRights:
-    "$id": "#/properties/accessRights"
-    "$comment": 'FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality
-      is 1:*'
-    title: The accessRights schema
-    description: The URL of a webpage where the data access request process and/or
-      guidance is provided. If there is more than one access process i.e. industry
-      vs academic please provide both. If such a resource or the underlying process
-      doesn’t exist, please provide “In Progress”, until both the process and the
-      documentation are ready.
-    anyOf:
-    - type: string
-      pattern: "^In Progress$"
-    - type: string
-      format: uri
-    - type: array
-      items:
-        type: string
-        format: uri
-  
-  group:
-    "$id": "#/properties/group"
-    "$comment": Conforms to spec, but this MAY be an array of groups
-    title: The group schema
-    description: An explanation about the purpose of this instance.
-    type: string
-  
-  description:
-    "$id": "#/properties/description"
-    title: The description schema
-    description: A free-text account of the record. An html account of the data that
-      provides context and scope of the data (limited to 50,000 characters) and/or
-      a resolvable URL that describes the dataset.
-    anyOf:
-    - type: string
+  summary:
+    id:
+      "$id": "#/properties/summary/id"
+      type: string
+      pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      minLength: 36
+      maxLength: 36
+      title: Dataset identifier
+      description: Dataset identifier
+    identifier:
+      "$id": "#/properties/summary/identifier"
+      "$comment": 'FIX SPEC: Conforms to spec, but this MAY be an array of strings.
+        FIXME: Rename to local identifier'
+      anyOf:
+      - type: string
+      - type: array
+        items:
+          type: string
+      title: Local dataset identifier
+      description: Local dataset identifier
+    name:
+      "$id": "#/properties/summary/name"
+      "$comment": 'using name from schema.org, title is reserved word in json schema'
+      type: string
+      minLength: 2
+      maxLength: 80
+      title: title
+      description: Name of the dataset limited to 80 characters. It should provide a
+        short description of the dataset and be unique across the gateway. If your title
+        is not unique, please add a prefix with your organisation name or identifier
+        to differentiate it from other datasets within the Gateway. Please avoid acronyms
+        wherever possible. Good titles should summarise the content of the dataset and
+        if relevant, the region the dataset covers.
+    abstract:
+      "$id": "#/properties/summary/abstract"
+      type: string
       minLength: 5
-      maxLength: 50000
-    - type: string
-      format: uri
-  
-  media:
-    "$id": "#/properties/media"
-    "$comment": 'FIXME: Conforms to spec, but this SHOULD to be an array of URIs as
-      cardinality 0:*'
-    title: The media schema
-    description: Please provide any media associated with the Gateway Organisation
-      using a valid URI. This is an opportunity to provide additional context that
-      could be useful for researchers wanting to undestand more about the dataset
-      and its relevance to their research question. The following formats will be
-      accepted .jpg, .png or .svg, .pdf, .xslx or .docx.
-    anyOf:
-    - type: string
-      format: uri
-    - type: array
-      items:
-        type: string
+      maxLength: 255
+      title: Dataset abstract
+      description: Provide a clear and brief descriptive signpost for researchers who
+        are searching for data that may be relevant to their research. The abstract
+        should allow the reader to determine the scope of the data collection and accurately
+        summarise its content. The optimal length is one paragraph (limited to 255 characters)
+        and effective abstracts should avoid long sentences and abbreviations where
+        possible
+    publisher:
+      "$id": "#/properties/summary/publisher"
+      "$comment": Conforms to spec, but this MAY be an an object of organisation
+      type: string
+      minLength: 2
+      maxLength: 80
+      title: Dataset publisher
+      description: This is the organisation responsible for running or supporting the
+        data access request process, as well as publishing and maintaining the metadata.
+        In most this will be the same as the HDR UK Organisation (Hub or Alliance Member).
+        However, in some cases this will be different i.e. Tissue Directory are an HDR
+        UK Gateway organisation but coordinate activities across a number of data publishers
+        i.e. Cambridge Blood and Stem Cell Biobank.
+    contactPoint:
+      "$id": "#/properties/summary/contactPoint"
+      type: string
+      format: email
+      title: The contactPoint schema  
+      description: An explanation about the purpose of this instance.
+    keywords:
+      "$id": "#/properties/summary/keywords"
+      "$comment": Conforms to spec, but this MAY be an array of strings
+      anyOf:
+        - type: string
+          pattern: "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+        - type: array
+          items:
+            type: string
+            pattern: "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+      type: string
+      pattern: "[0-9a-zA-Z._\\-]+(,[0-9a-zA-Z.\\-_]+)*"
+      title: The keywords schema
+      description: An explanation about the purpose of this instance.
+    doiName:
+      "$id": "#/properties/summary/doiName"
+      anyOf:
+      - type: string
+        enum:
+        - In Progress
+      - type: string
+        pattern: '^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$'
+        title: Digital Object Identifier
+        description: All HDR UK registered datasets should either have a Digital Object
+            Identifier (DOI) or be working towards obtaining one. If a DOI is available,
+            please provide the DOI. 
+  documentation:
+    shortDescription:
+      "$id": "#/properties/documentation/shortDescription"
+      type: string
+      minLength: 5
+      maxLength: 3000
+      pattern: "/^.{5,3000}$"
+      title: The short description
+      description: A free-text description of the record.
+    additionalDocumentation:
+      "$id": "#/properties/documentation/additionalDocumentation"
+      type: string
+      pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
+      title: Digital Object Identifier
+      description: All HDR UK registered datasets should either have a Digital Object
+              Identifier (DOI) or be working towards obtaining one. If a DOI is available,
+              please provide the DOI.         
+    additionalMedia:
+      "$id": "#/properties/documentation/additionalMedia"
+      "$comment": 'FIXME: Conforms to spec, but this SHOULD to be an array of URIs as
+        cardinality 0:*'
+      anyOf:
+      - type: string
         format: uri
-  
-  purpose:
-    "$id": "#/properties/purpose"
-    "$comment": 'FIXME: Mandatory, but cardinality 0:* Possibly deprecate.'
-    title: The purpose schema
-    description: Pleases indicate the purpose(s) that the dataset was collected. Multiple
-      purposes may be provided
-    anyOf:
-    - type: string
-      enum:
-      - Study
-      - Disease Registry
-      - Trial
-      - Care
-      - Audit
-      - Administrative
-      - Financial
-    - type: array
-      items:
+      - type: array
+        items:
+          type: string
+          format: uri
+      title: The media schema
+      description: Please provide any media associated with the Gateway Organisation
+        using a valid URI. This is an opportunity to provide additional context that
+        could be useful for researchers wanting to undestand more about the dataset
+        and its relevance to their research question. The following formats will be
+        accepted .jpg, .png or .svg, .pdf, .xslx or .docx.
+    isPartOf:
+      "$id": "#/properties/documentation/isPartOf"
+      "$comment": Conforms to spec, but this MAY be an array of groups
+      type: string
+      title: The group schema
+      description: An explanation about the purpose of this instance. 
+  coverage:
+    spatial:
+      "$id": "#/properties/coverage/spatial"
+      "$comment": 'FIXME: Update to geoname pattern'
+      type: string
+      format: uri
+      title: The geographicCoverage schema
+      description: The geographical area covered by the dataset.
+      default: ''
+      examples:
+      - GB  
+    typicalAgeRange:
+      "$id": "#/properties/coverage/TypicalAgeRange"
+      "$comment": 'FIXME: Rename MDC response to ageRange according to spec'
+      type: string
+      pattern: "\\d{1,3}-\\d{1,3}"
+      title: TypicalAgeRange
+      description: Please indicate the age range in whole years of participants in the
+       dataset. Please provide range in the following format ‘[min age] – [max age]’
+       where both the minimum and maximum are whole numbers (integers).
+    physicalSampleAvailability:
+        "$id": "#/properties/coverage/physicalSampleAvailability"
         type: string
         enum:
-        - Study
-        - Disease Registry
-        - Trial
-        - Care
-        - Audit
-        - Administrative
-        - Financial
-  
-  source:
-    "$id": "#/properties/source"
-    "$comment": 'FIXME: Mandatory, but cardinality 0:* Possibly deprecate.'
-    title: The source schema
-    description: Pleases indicate the source(s) that the dataset was collected. Multiple
-      source(s) may be provided
-    anyOf:
-    - type: string
+        - Not Available
+        - Bone Marrow
+        - Cancer Cell Lines
+        - Core Biopsy
+        - CDNA/MRNA
+        - DNA
+        - Faeces
+        - Immortalized Cel Lines
+        - MicroRNA
+        - Peripheral Blood Cells
+        - Plasma
+        - PM Tissue
+        - Primary Cells
+        - RNA
+        - Saliva
+        - Serum
+        - Swabs
+        - Tissue
+        - Urine
+        - Whole Blood
+        - Availability To Be Confirmed
+        title: The physicalSampleAvailability schema
+        description: Availability of physical samples associated with the dataset. If
+          samples are available, please indicate the types of samples that are available.
+        default: ''
+        examples:
+        - Not Available 
+    followUp:
+      "$id": "#/properties/coverage/followUp"
+      type: string
       enum:
-      - Epr
-      - Electronic Survey
-      - Lims
-      - Paper Based
-      - Freetext Nlp
-      - Machine Generated
-    - type: array
-      items:
+        - 0 - 6 MONTHS
+        - 6 - 12 MONTHS
+        - 1 - 10 YEARS	
+        - greater than 10 YEARS	
+        - UNKNOWN
+      title: Follow Up
+      description: If known, what is the typical time span that a patient appears in the dataset (follow up period)
+    pathway:
+        "$id": "#/properties/coverage/pathway"
+        type: string
+        minLength: 5
+        maxLength: 3000
+        pattern: "/^.{5,3000}$"
+        title: The short description
+        description: A free-text description of the record.
+  provenance:
+    origin:
+      properties:
+      purpose:
+        "$id": "#/properties/provenance/orgin/purpose"
+        "$comment": 'FIXME: Mandatory, but cardinality 0:* Possibly deprecate.'
+        anyOf:
+        - type: string
+          enum:
+          - Study
+          - Disease Registry
+          - Trial
+          - Care
+          - Audit
+          - Administrative
+          - Financial
+          - Other
+        - type: array
+          items:
+            type: string
+            enum:
+            - Study
+            - Disease Registry
+            - Trial
+            - Care
+            - Audit
+            - Administrative
+            - Financial
+            - Other
+        title: The purpose schema
+        description: Pleases indicate the purpose(s) that the dataset was collected. Multiple
+          purposes may be provided
+      source:
+        "$id": "#/properties/provenance/orgin/source"
+        "$comment": 'FIXME: Mandatory, but cardinality 0:* Possibly deprecate.'
+        anyOf:
+          - type: string
+            enum:
+            - Epr
+            - Electronic Survey
+            - Lims
+            - Paper Based
+            - Freetext Nlp
+            - Machine Generated
+          - type: array
+            items:
+              type: string
+              enum:
+              - Epr
+              - Electronic Survey
+              - Lims
+              - Paper Based
+              - Freetext Nlp
+              - Machine Generated
+        title: The source schema
+        description: Pleases indicate the source(s) that the dataset was collected. Multiple
+            source(s) may be provided
+      collectionSituation:
+        "$id": "#/properties/provenance/orgin/collectionSituation"
+        anyOf:
+        - type: string
+          enum:
+          - CLINIC
+          - PRIMARY CARE
+          - ACCIDENT AN EMERGENCY
+          - OUTPATIENTS
+          - IN-PATIENTS
+          - SERVICES
+          - COMMUNITY
+          - HOME
+          - PRIVATE
+          - PHARMACY
+          - OTHER
+        - type: array
+          items:
+            type: string
+            enum:
+            - CLINIC
+            - PRIMARY CARE
+            - ACCIDENT AN EMERGENCY
+            - OUTPATIENTS
+            - IN-PATIENTS
+            - SERVICES
+            - COMMUNITY
+            - HOME
+            - PRIVATE
+            - PHARMACY
+            - OTHER
+        title: The purpose schema
+        description: Pleases indicate the purpose(s) that the dataset was collected. Multiple
+          purposes may be provided - see https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/FieldLevelDocumentation/schemas/datacollection_xsd/elements/CollectionSituation.html
+    temporal:
+      accrualPeriodicity:
+        "$id": "#/properties/provenance/temporal/accrualPeriodicity"
         type: string
         enum:
-        - Epr
-        - Electronic Survey
-        - Lims
-        - Paper Based
-        - Freetext Nlp
-        - Machine Generated
-  
-  
-  setting:
-    "$id": "#/properties/setting"
-    "$comment": 'FIXME: Mandatory, but cardinality 0:*. Possibly deprecate.'
-    title: The setting schema
-    description: Pleases indicate the setting(s) where data was collected. Multiple
-      settings may be provided.
-    anyOf:
-    - type: string
-      enum:
-      - Clinic
-      - Primary Care
-      - Accident and Emergency
-      - Outpatients
-      - In-Patients
-      - Services
-      - Community
-      - Home
-      - Private
-      - Pharmacy
-    - type: array
-      items:
+          - Static
+          - Annual
+          - Biannual
+          - Biennial
+          - Quarterly
+          - Bimonthly
+          - Monthly
+          - Biweekly
+          - Daily
+          - Irregular
+          - Continuous
+        title: Periodicity
+        "$comment": dct:accrualPeriodicity
+        description: 'Please indicate the frequency of publishing. If a dataset is
+          published regularly please choose a publishing periodicity from the constrained
+          list and indicate the next release date. When the release date becomes historical,
+          a new release date will be calculated based on the publishing periodicity.
+          If a dataset has been published and will remain static please indicate that
+          it is static and indicated when it was released. If a dataset is released
+          on an irregular basis or “on-demand” please indicate that it is Irregular
+          and leave release date as null. If a dataset can be published in real-time
+          or near-real-time please indicate that it is continuous and leave release
+          date as null. Notes: see https://www.dublincore.org/specifications/dublin-core/collection-description/frequency/'
+        "$ref": "#/definitions/periodicity"
+        default: ''
+      distibutionReleaseDate:
+        "$id": "#/properties/provenance/temporal/distibutionReleaseDate"
+        type: string
+        format: date-time
+        title: The releaseDate schema
+        description: Date of the latest release of the dataset. If this is a regular release i.e. quarterly, or this is a static dataset please complete this alongside Periodicity. 
+      endDate:
+        "$id": "#/properties/provenance/temporal/endDate"
+        type: string
+        format: date
+        title: The datasetEndDate schema
+        description: The end of the time period that the dataset provides coverage for.
+      startDate:
+        "$id": "#/properties/provenance/temporal/startDate"
+        type: string
+        format: date
+        title: The datasetStartDate schema
+        description: The start of the time period that the dataset provides coverage for.
+      timeLag:
+        "$id": "#/properties/provenance/temporal/timeLag"
         type: string
         enum:
-        - Clinic
-        - Primary Care
-        - Accident and Emergency
-        - Outpatients
-        - In-Patients
-        - Services
-        - Community
-        - Home
-        - Private
-        - Pharmacy
-  
+          - less than 1 WEEK
+          - 1-2 WEEKS
+          - 2-4 WEEKS
+          - 1-2 MONTHS
+          - 2-6 MONTHS
+          - greater than 6 MONTHS
+          - VARIABLE
+          - NA
+        title: Time Lag
+        description: Please indicate the typical time-lag between an event and the data for that event appearing in the dataset.
+  accessibility:
+    usage:
+      dataUseLimitation:
+          "$id": "#/properties/accessibility/usage/dataUseLimitation"
+          type: string
+          enum:
+            - GENERAL RESEARCH USE
+            - GENETIC STUDIES ONLY
+            - NO GENERAL METHODS RESEARCH
+            - NO RESTRICTION
+            - RESEARCH SPECIFIC RESTRICTIONS
+            - RESEARCH USE ONLY
+            - NO LINKAGE
+          title: Data Use Limitation
+          description: An indication of consent permissions for datasets and/or materials, and relates to the purposes for which datasets and/or material might be removed, stored or used.
+      dataUseRequirements:
+          "$id": "#/properties/accessibility/usage/dataUseRequirements"
+          type: string
+          enum:
+            - COLLABORATION REQUIRED
+            - ETHICS APPROVAL REQUIRED
+            - GEOGRAPHICAL RESTRICTIONS
+            - INSTITUTION SPECIFIC RESTRICTIONS
+            - NOT FOR PROFIT USE
+            - PROJECT SPECIFIC RESTRICTIONS
+            - PUBLICATION MORATORIUM
+            - PUBLICATION REQUIRED
+            - RETURN TO DATABASE OR RESOURCE
+            - TIME LIMIT ON USE
+            - USER SPECIFIC RESTRICTION
+          title: Data Use Limitation
+          description: An indication of consent permissions for datasets and/or materials, and relates to the purposes for which datasets and/or material might be removed, stored or used.
+      resourceCreator:
+          "$id": "#/properties/accessibility/usage/resourceCreator"
+          type: string
+          title: The creator schema
+          description: Please provide the text that you would like included as part of any citation that credits this dataset. This is typically just the name of the publisher.   No employee details should be provided.
+      investigations:
+          type: string
+          pattern: '^\\((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)'
+          title: Investigations
+          description: Please provide a link to any active projects that are using the dataset.
+      isReferencedBy:
+          anyOf:
+            - type: string
+              pattern: '^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$'
+            - type: array
+              items:
+                type: string
+                pattern: '^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$'
+          title: Is Referenced By
+          description: The keystone paper associated with the dataset. Also include a list of known citations, if available and should be links to existing resources where the dataset has been used or referenced. 
+    access:
+      accessRights:
+          "$id": "#/properties/accessibility/access/accessRights"
+          "$comment": 'FIXME: Conforms to spec, but this SHOULD be an array or URIs as cardinality
+          is 1:*'
+          anyOf:
+            - type: string
+              pattern: "^In Progress$"
+            - type: string
+              format: uri
+            - type: array
+              items:
+                type: string
+                format: uri
+          title: The accessRights schema
+          description: The URL of a webpage where the data access request process and/or
+            guidance is provided. If there is more than one access process i.e. industry
+            vs academic please provide both. If such a resource or the underlying process
+            doesn’t exist, please provide “In Progress”, until both the process and the
+            documentation are ready.
+      accessService:
+          "$id": "#/properties/accessibility/access/accessService"
+          type: string
+          pattern: "^.{5,5000}$"
+          title: Access Service
+          description: Please provide a brief description of the environment where data can be accessed by researchers. If no environment is currently available, please indicate the current plans and timelines when the data will be made available through an access environment or process.
+      deliveryLeadTime:
+          "$id": "#/properties/accessibility/access/deliveryLeadTime"
+          type: string
+          enum:
+            - "less than 1 Week"
+            - 1-2 Weeks
+            - 2-4 Weeks
+            - 1-2 Months
+            - 2-6 Months
+            - "greater than 6 Months"
+            - Other
+          title: The accessRequestDuration schema
+          description: Please provide an indication of the typical processing times based
+            on the types of requests typically received.
+      accessRequests:
+          "$id": "#/properties/accessibility/access/accessRequests"
+          type: integer
+          title: Access Requests
+          description: Please indicate the number of data access requests that have been received for the dataset.
+      jurisdiction:
+          "$id": "#/properties/jurisdiction"
+          "$comment": 'FIXME: Add ISO 3166-2 Subdivision code pattern'
+          type: string
+          pattern: '^[A-Z]{2}(-[A-Z]{2,3})?$'
+          title: The jurisdiction schema
+          description: Please use country code from ISO 3166-1 country codes and the associated
+            ISO 3166-2 for regions, cities, states etc. for the country/state under whose
+            laws the data subjects’ data is collected, processed and stored.
+      dataController:
+          "$id": "#/properties/accessibility/access/dataController"
+          type: string
+          title: Data Controller
+          description: Data Controller means a person/entity who (either alone or jointly or in common with other persons/entities) determines the purposes for which and the way any Data Subject data, specifically personal data or are to be processed.
+      dataProcessor:
+          "$id": "#/properties/accessibility/access/dataProcessor"
+          type: string
+          title: Data Processor
+          description: A Data Processor, in relation to any Data Subject data, specifically personal data, means any person/entity (other than an employee of the data controller) who processes the data on behalf of the data controller.
+      formatAndStandards:
+        vocabularyEncodingScheme:
+          "$id": "#/properties/properties/accessibility/formatAndStandards/vocabularyEncodingScheme"
+          "$comment": 'FIXME: Confroms to spec, but MAY be a list of strings'
+          anyOf:
+            - type: string
+              enum:
+                - LOCAL
+                - OPCS4
+                - READ
+                - SNOMED CT
+                - SNOMED RT
+                - DM+D
+                - NHS NATIONAL CODES
+                - ODS
+                - LOINC
+                - ICD10
+                - ICD10CM
+                - ICD10PCS
+                - ICD9CM
+                - ICD9
+                - ICDO3
+                - AMT
+                - APC
+                - ATC
+                - CIEL
+                - HPO
+                - CPT4
+                - DPD
+                - DRG
+                - HEMONIC
+                - JMDC
+                - KCD7
+                - MULTUM
+                - NAACCR
+                - NDC
+                - NDFRT
+                - OXMIS
+                - RXNORM
+                - RXNORM EXTENSION
+                - SPL
+                - OTHER
+            - type: array
+              items:
+                type: string
+                enum:
+                    - LOCAL
+                    - OPCS4
+                    - READ
+                    - SNOMED CT
+                    - SNOMED RT
+                    - DM+D
+                    - NHS NATIONAL CODES
+                    - ODS
+                    - LOINC
+                    - ICD10
+                    - ICD10CM
+                    - ICD10PCS
+                    - ICD9CM
+                    - ICD9
+                    - ICDO3
+                    - AMT
+                    - APC
+                    - ATC
+                    - CIEL
+                    - HPO
+                    - CPT4
+                    - DPD
+                    - DRG
+                    - HEMONIC
+                    - JMDC
+                    - KCD7
+                    - MULTUM
+                    - NAACCR
+                    - NDC
+                    - NDFRT
+                    - OXMIS
+                    - RXNORM
+                    - RXNORM EXTENSION
+                    - SPL
+                    - OTHER
+          title: The controlledVocabulary schema
+          description: List any relevant terminologies / ontologies / controlled vocabularies,
+                such as ICD 10 Codes, NHS Data Dictionary National Codes or SNOMED CT International,
+                that are being used by the dataset.
+          default: ''
+          examples:
+              - See ConformsTo
+        conformsTo:
+          "$id": "#/properties/conformsTo"
+          type: string
+          enum:
+          - HL7 FHIR
+          - HL7 V2
+          - HL7 CDA
+          - HL7 CCOW
+          - LOINC
+          - DICOM
+          - I2B2
+          - IHE
+          - OMOP
+          - OPENEHR
+          - SENTINEL
+          - PCORNET
+          - LOCAL
+          - CDISC 
+          - OTHER
+          title: The conformsTo schema
+          description: An explanation about the purpose of this instance.
+        language:
+          "$id": "#/properties/language"
+          "$comment": 'FIXME: Conforms to spec, but may be a list of strings given cardinality
+            1:*. Validate against external list of languages. Resources defined by the Library
+            of Congress (ISO 639-1, ISO 639-2) SHOULD be used.'
+          anyOf:
+          - type: string
+          - type: array
+            items:
+              type: string
+          title: The language schema
+          description: This should list all the languages in which the dataset metadata
+            and underlying data is made available.
+        format:
+          "$id": "#/properties/format"
+          "$comment": 'FIXME: Conforms to spec, but may be a list of strings given cardinality
+            1:*. Validate against external list of formats, e.g. https://www.iana.org/assignments/media-types/media-types.xhtml'
+          anyOf:
+          - type: string
+          - type: array
+            items:
+              type: string
+          title: The format schema
+          description: If multiple formats are available please specify. 
   releaseDate:
     "$id": "#/properties/releaseDate"
-    title: The releaseDate schema
-    description: An explanation about the purpose of this instance.
     type: string
     format: date-time
-  
+    title: The releaseDate schema
+    description: An explanation about the purpose of this instance.
   accessRequestCost:
     "$id": "#/properties/accessRequestCost"
+    type: string
     title: The accessRequestCost schema
     description: An explanation about the purpose of this instance.
-    type: string
-  
-  accessRequestDuration:
-    "$id": "#/properties/accessRequestDuration"
-    title: The accessRequestDuration schema
-    description: Please provide an indication of the typical processing times based
-      on the types of requests typically received.
-    type: string
-    enum:
-    - "<1 Week"
-    - 1-2 Weeks
-    - 2-4 Weeks
-    - 1-2 Months
-    - 2-6 Months
-    - ">6 Months"
-    - Other
   
   accessEnvironment:
     "$id": "#/properties/accessEnvironment"
-    title: The accessEnvironment schema
-    description: Please provide a brief description of the data access environment
-      that is currently available to researchers.
     type: string
     minLength: 5
     maxLength: 5000
-  
-  usageRestrictions:
-    "$id": "#/properties/usageRestrictions"
-    "$comment": 'FIXME: Missing from Onboarding tool, so not captured'
-    title: The usageRestrictions schema
-    description: Please provide a description of any usage restrictions of key terms
-      and conditions under which access to the dataset is provided.
-    anyOf:
-    - type: string
-      minLength: 5
-      maxLength: 50000
-    - type: string
-      enum:
-      - In Progress
+    title: The accessEnvironment schema
+    description: Please provide a brief description of the data access environment
+      that is currently available to researchers.
   
   dataController:
     "$id": "#/properties/dataController"
+    type: string
+    minLength: 5
+    maxLength: 5000
     title: The dataController schema
     description: Data Controller means a person/entity who (either alone or jointly
       or in common with other persons/entities) determines the purposes for which
       and the way any Data Subject data, specifically personal data or are to be processed.
-    type: string
-    minLength: 5
-    maxLength: 5000
-  
   dataProcessor:
     "$id": "#/properties/dataProcessor"
-    title: The dataProcessor schema
-    description: A Data Processor, in relation to any Data Subject data, specifically
-      personal data, means any person/entity (other than an employee of the data controller)
-      who processes the data on behalf of the data controller.
     anyOf:
     - type: string
       minLength: 5
@@ -355,20 +670,19 @@ properties:
     - type: string
       enum:
       - Not Applicable
-  
+    title: The dataProcessor schema
+    description: A Data Processor, in relation to any Data Subject data, specifically
+      personal data, means any person/entity (other than an employee of the data controller)
+      who processes the data on behalf of the data controller.
   license:
     "$id": "#/properties/license"
+    type: string
     title: The license schema
     description: An explanation about the purpose of this instance.
-    type: string
-  
   derivedDatasets:
     "$id": "#/properties/derivedDatasets"
     "$comment": 'FIXME: Conforms to spec, but this SHOULD to be an array of datasets
       as cardinality 0:*'
-    title: The derivedDatasets schema
-    description: Indicate if derived datasets or predefined extracts are available
-      and the type of derivation available.
     anyOf:
     - type: string
       format: uri
@@ -380,30 +694,38 @@ properties:
       enum:
       - Not Known
       - Not Available
-  
+    title: The derivedDatasets schema
+    description: Indicate if derived datasets or predefined extracts are available
+      and the type of derivation available.
   linkedDataset:
     "$id": "#/properties/linkedDataset"
     "$comment": 'FIXME: If linked $title must start with ''Linked''. FIXME: Conforms
       to spec, but this SHOULD to be an array of datasets as cardinality 0:*'
+    anyOf:
+    - type: string
+      format: uri
+    - type: array
+      items:
+        type: string
+        format: uri
+    - type: string
+      enum:
+      - Not Known
+      - Not Available
     title: The linkedDataset schema
     description: If applicable, please provide the DOI of other datasets that have
       previously been linked to this dataset and their availability. If no DOI is
       available, please provide the title of the datasets that can be linked, where
       possible using the same title of a dataset previously onboarded.
+  linkageOpportunity:
+    "$id": "#/properties/linkageOpportunity"
     anyOf:
     - type: string
-      format: uri
-    - type: array
-      items:
-        type: string
-        format: uri
     - type: string
       enum:
       - Not Known
       - Not Available
-  
-  linkageOpportunity:
-    "$id": "#/properties/linkageOpportunity"
+    type: string
     title: The linkageOpportunity schema
     description: If applicable, please indicate if there is the opportunity to link
       this dataset to additional data sources. If possible, please describe the data
@@ -411,218 +733,160 @@ properties:
       postcode could be used to link to open datasets such as air pollution or deprivation
       indices. In addition, please describe the restricted data elements that cannot
       be used to link to other datasets.
-    anyOf:
-    - type: string
-    - type: string
-      enum:
-      - Not Known
-      - Not Available
-    type: string
-  
   geographicCoverage:
     "$id": "#/properties/geographicCoverage"
     "$comment": 'FIXME: Update to geoname pattern'
-    title: The geographicCoverage schema
-    description: The geographical area covered by the dataset.
     type: string
     format: uri
+    title: The geographicCoverage schema
+    description: The geographical area covered by the dataset.
     default: ''
     examples:
     - GB
-  
   periodicity:
     "$id": "#/properties/periodicity"
+    type: string
+    enum:
+    - Static
+    - Annual
+    - Biennial
+    - Quaterly
+    - Bimonthly
+    - Monthly
+    - Biweekly
+    - Daily
+    - Irregular
+    - Continious
     title: The periodicity schema
     description: The frequency at which dataset is published.
-    "$ref": "#/definitions/periodicity"
-  
   datasetEndDate:
     "$id": "#/properties/datasetEndDate"
+    type: string
+    format: date
     title: The datasetEndDate schema
     description: The end of the time period that the dataset provides coverage for.
-    type: string
-    format: date
-  
   datasetStartDate:
     "$id": "#/properties/datasetStartDate"
-    title: The datasetStartDate schema
-    description: The start of the time period that the dataset provides coverage for.
     type: string
     format: date
-    
-  
-  jurisdiction:
-    "$id": "#/properties/jurisdiction"
-    "$comment": 'FIXME: Add ISO 3166-2 Subdivision code pattern'
-    title: The jurisdiction schema
-    description: Please use country code from ISO 3166-1 country codes and the associated
-      ISO 3166-2 for regions, cities, states etc. for the country/state under whose
-      laws the data subjects’ data is collected, processed and stored.
-    type: string
-    pattern: "^[A-Z]{2}(-[A-Z]{2,3})?$"
+    title: The datasetStartDate schema
+    description: The start of the time period that the dataset provides coverage for.
   
   populationType:
     "$id": "#/properties/populationType"
     "$comment": 'FIXME: Check against SNOMED-CT TERMS. Conforms to spec but MAY be
       array of strings'
+    anyOf:
+    - type: string
+    - type: array
+      items:
+        type: string
     title: The populationType schema
     description: Please provide a valid SNOMED CT concept that describes the measure
       within the dataset i.e. participants in a study, modality, or images with certain
       characteristics.
-    anyOf:
-    - type: string
-    - type: array
-      items:
-        type: string
-    
   disabmiguatingDescription:
     "$id": "#/properties/disabmiguatingDescription"
-    "$comment": 'FIXME: MDC is not populated with this value'
+    "$comment": 'FIXME: Rename MDC response to ageRange according to spec'
+    type: string
+    pattern: "\\d{1,3}-\\d{1,3}"
     title: The disabmiguatingDescription schema
     description: If SNOMED CT term does not provide sufficient detail, please provide
       a description that disambiguates the population type.
-    type: string
-    
-  
   statisticalPopulation:
     "$id": "#/properties/statisticalPopulation"
     "$comment": 'FIXME: Spec calls this Measured Value'
-    title: The statisticalPopulation schema
-    description: An explanation about the purpose of this instance.
     anyOf:
     - type: string
     - type: array
       items:
         type: string
-    
-  
+    title: The statisticalPopulation schema
+    description: An explanation about the purpose of this instance.
   ageBand:
     "$id": "#/properties/ageBand"
     "$comment": 'FIXME: Rename MDC response to ageRange according to spec'
+    type: string
+    pattern: "\\d{1,3}-\\d{1,3}"
     title: The ageBand schema
     description: Please indicate the age range in whole years of participants in the
       dataset. Please provide range in the following format ‘[min age] – [max age]’
       where both the minimum and maximum are whole numbers (integers).
-    "$ref": "#/definitions/numericRange"
-  
   physicalSampleAvailability:
     "$id": "#/properties/physicalSampleAvailability"
-    "$comment": Conforms to spec, but this MAY be an array of strings
+    type: string
+    enum:
+    - Not Available
+    - Bone Marrow
+    - Cancer Cell Lines
+    - Core Biopsy
+    - CDNA/MRNA
+    - DNA
+    - Faeces
+    - Immortalized Cel Lines
+    - MicroRNA
+    - Peripheral Blood Cells
+    - Plasma
+    - PM Tissue
+    - Primary Cells
+    - RNA
+    - Saliva
+    - Serum
+    - Swabs
+    - Tissue
+    - Urine
+    - Whole Blood
+    - Availability To Be Confirmed
     title: The physicalSampleAvailability schema
     description: Availability of physical samples associated with the dataset. If
       samples are available, please indicate the types of samples that are available.
-    anyOf:
-    - "$ref": "#/definitions/physicalSampleAvailability"
-    - type: array
-      items:
-        "$ref": "#/definitions/physicalSampleAvailability"
     default: ''
     examples:
     - Not Available
   
-  keywords:
-    "$id": "#/properties/keywords"
-    "$comment": Conforms to spec, but this MAY be an array of strings
-    title: The keywords schema
-    description: An explanation about the purpose of this instance.
-    anyOf:
-    - "$ref": "#/definitions/commaSeparatedValues"
-    - type: array
-      items:
-        "$ref": "#/definitions/commaSeparatedValues"
-  
-  conformsTo:
-    title: The conformsTo schema
-    description: An explanation about the purpose of this instance.
-    "$id": "#/properties/conformsTo"
-    "$ref": "#/definitions/conformsTo"
-  
-  controlledVocabulary:
-    "$id": "#/properties/controlledVocabulary"
-    "$comment": 'FIXME: Confroms to spec, but MAY be a list of strings'
-    title: The controlledVocabulary schema
-    description: List any relevant terminologies / ontologies / controlled vocabularies,
-      such as ICD 10 Codes, NHS Data Dictionary National Codes or SNOMED CT International,
-      that are being used by the dataset.    
-    anyOf:
-    - "$ref": "#/definitions/controlledVocabulary"
-    - type: array
-      items:
-        "$ref": "#/definitions/controlledVocabulary"
-    default: ''
-    examples:
-    - See ConformsTo
-  
-  language:
-    "$id": "#/properties/language"
-    "$comment": 'FIXME: Conforms to spec, but may be a list of strings given cardinality
-      1:*. Validate against external list of languages. Resources defined by the Library
-      of Congress (ISO 639-1, ISO 639-2) SHOULD be used.'
-    title: The language schema
-    description: This should list all the languages in which the dataset metadata
-      and underlying data is made available.
-    anyOf:
-    - type: string
-    - type: array
-      items:
-        type: string
-  
-  format:
-    "$id": "#/properties/format"
-    "$comment": 'FIXME: Conforms to spec, but may be a list of strings given cardinality
-      1:*. Validate against external list of formats, e.g. https://www.iana.org/assignments/media-types/media-types.xhtml'
-    title: The format schema
-    description: If multiple formats are available please specify.
-    anyOf:
-    - type: string
-    - type: array
-      items:
-        type: string
-  
   fileSize:
     "$id": "#/properties/fileSize"
+    type: string
     title: The fileSize schema
     description: An explanation about the purpose of this instance.
-    type: string
     default: ''
     examples:
     - 301MB
   
-  creator:
-    "$id": "#/properties/creator"
-    title: The creator schema
-    description: Please provide the text that you would like included as part of any
-      citation that credits this dataset. This is typically just the name of the publisher.
-      No employee details should be provided.
-    type: string
-  
   citations:
     "$id": "#/properties/citations"
     "$comment": 'FIXME: Conforms to spec, but may be a list of citation strings'
-    title: The citations schema
-    description: Please provide the keystone paper associated with the dataset. Also
-      include a list of known citations, if available and should be links to existing
-      resources where the dataset has been used or referenced.
     anyOf:
     - type: string
     - type: array
       items:
         type: string
-  
-  doi:
-    "$id": "#/properties/doi"
-    title: Digital Object Identifier
-    description: All HDR UK registered datasets should either have a Digital Object
-      Identifier (DOI) or be working towards obtaining one. If a DOI is available,
-      please provide the DOI.
-    anyOf:
-    - type: string
-      enum:
-      - In Progress
-    - type: string
-      pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
+    title: The citations schema
+    description: Please provide the keystone paper associated with the dataset. Also
+      include a list of known citations, if available and should be links to existing
+      resources where the dataset has been used or referenced.
 
 definitions:
+  uuidv4:
+    type: string
+    pattern: "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+    minLength: 36
+    maxLength: 36
+  
+  eightyCharacters:
+    type: string
+    minLength: 2
+    maxLength: 80
+  
+  abstractText:
+    type: string
+    minLength: 5
+    maxLength: 255
+  
+  emailAddress:
+    type: string
+    format: email
+  
   commaSeparatedValues:
     type: string
     pattern: "([^,]+)"
@@ -631,28 +895,9 @@ definitions:
     type: string
     pattern: "\\d{1,3}-\\d{1,3}"
   
-  semver:
-    title: Semantic Version
-    description: Semantic versioning of the using a dotted numeric format 
-      MAJOR.MINOR.PATCH
+  doi:
     type: string
-    pattern: "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$"
-  
-  revisions:
-    type: array
-    items:
-      type: object
-      required:
-      - version
-      - url
-      properties:
-        version:
-          description: Semantic Version
-          "$ref": "#/definitions/semver"
-        url:
-          description: URL endpoint to obtain the version
-          type: string
-          format: uri
+    pattern: "^10.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
   
   controlledVocabulary:
     type: string
@@ -741,8 +986,9 @@ definitions:
     type: string
     enum:
     - STATIC
-    - ANNUAL
     - BIENNIAL
+    - ANNUAL
+    - BIANNUAL
     - QUARTERLY
     - BIMONTHLY
     - MONTHLY
@@ -752,3 +998,5 @@ definitions:
     - DAILY
     - IRREGULAR
     - CONTINUOUS
+
+ 

--- a/schema/dataset/latest/dataset.schema.yaml
+++ b/schema/dataset/latest/dataset.schema.yaml
@@ -9,6 +9,8 @@ required:
 - id
 - version
 - revisions
+- issued
+- modified
 - title
 - abstract
 - publisher
@@ -56,6 +58,22 @@ properties:
     title: Dataset Revisions
     description: Revisions of Dataset metadata
     "$ref": "#/definitions/revisions"
+  
+  issued:
+    "$id": "#/properties/issued"
+    title: Creation Date
+    "$comment": 'dcat:issued'
+    description: Dataset Metadata Creation Date
+    type: string
+    format: date-time
+  
+  modified:
+    "$id": "#/properties/modified"
+    title: Modification Date
+    "$comment": 'dcat:modified'
+    description: Dataset Metadata Creation Date
+    type: string
+    format: date-time
   
   identifier:
     "$id": "#/properties/identifier"


### PR DESCRIPTION
Summary & Motivation:

This RFC introduces a new accessibility object that provides two new sub-properties usage, access, format & standard
Authors:

    A. Milward (MetadataWorks)
    D. Milward (MetadataWorks)
    S. Varma (HDR UK)

Detailed List Of Changes:

This RFC is limited to the creation of a new accessibility object property and its related definitions which are listed below:

New/Modified Definitions:
Rearranged properties in new section called accessibility as follows:
accessibility(new item)  :       
  -usage(new item)  :         
    --dataUseLimitation (was usageRestrictions)         
    --dataUseRequirements: (new item)         
    --resourceCreator: (was creator - is now optional)         
    --investigations:         
    --isReferencedBy (was citations)       
  -access(new item)  :         
    --accessRights:         
    --accessService: (was accessEnvironment)         
    --deliveryLeadTime: (was accessRequestDuration)(changed < and > to characters)         
    --jurisdiction:         
    --dataController:         
    --dataProcessor:       
  -formatAndStandards(new item)  :         
    --vocabularyEncodingScheme: (was vocabulary)         
    --conformsTo:         
    --language:         
    --format:  

Required Properties:
  
-access (not required - but if used then the following are required)
--accessRights
--jurisdiction
--dataController
-formatAndStandards (not required - but if used then the following are required)
- conformsTo
- language
- format

   
Breaking Changes:
   All - since all these properties are under the new structure
   

Unresolved Questions:

   
